### PR TITLE
Set proper properties for the IG

### DIFF
--- a/ig.ini
+++ b/ig.ini
@@ -1,3 +1,3 @@
 [IG]
-ig = fsh-generated/resources/ImplementationGuide-hl7-core-profiling.json
+ig = fsh-generated/resources/ImplementationGuide-finnish-base-profiles.json
 template = fhir.base.template#current

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -3,28 +3,31 @@
 # │  used properties are included. For a list of all supported properties and their functions,     │
 # │  see: https://fshschool.org/docs/sushi/configuration/.                                         │
 # ╰────────────────────────────────────────────────────────────────────────────────────────────────╯
-id: hl7-core-profiling
-canonical: http://hl7.fi/fhir
-name: HL7CoreProfiling
-# title: Example Title
-# description: Example Implementation Guide for getting started with SUSHI
+id: finnish-base-profiles
+canonical: http://hl7.fi/fhir/finnish-base-profiles
+name: FinnishBaseProfiles
+title: Finnish Base Profiles
+description: A core set of FHIR resources profiled for use in Finland, published and maintained by HL7 Finland
 status: draft # draft | active | retired | unknown
 version: 0.1.0
 fhirVersion: 4.0.1 # https://www.hl7.org/fhir/valueset-FHIR-version.html
 copyrightYear: 2022+
 releaseLabel: draft # ci-build | draft | qa-preview | ballot | trial-use | release | update | normative+trial-use
-# license: CC0-1.0 # https://www.hl7.org/fhir/valueset-spdx-license.html
-# jurisdiction: urn:iso:std:iso:3166#US "United States of America" # https://www.hl7.org/fhir/valueset-jurisdiction.html
+license: CC0-1.0 # https://www.hl7.org/fhir/valueset-spdx-license.html
+jurisdiction: urn:iso:std:iso:3166#FI "Finland" # https://www.hl7.org/fhir/valueset-jurisdiction.html
 publisher:
-  name: Hl7CorePublisher
-  url: http://hl7.fi/fhir/finnishCorePublisher
+  name: HL7 Finland
+  url: https://www.hl7.fi/
   # email: test@example.org
 
 # The dependencies property corresponds to IG.dependsOn. The key is the
 # package id and the value is the version (or dev/current). For advanced
 # use cases, the value can be an object with keys for id, uri, and version.
 #
-# dependencies:
+
+dependencies:
+  hl7.fhir.uv.ipa: 0.1.0
+
 #   hl7.fhir.us.core: 3.1.0
 #   hl7.fhir.us.mcode:
 #     id: mcode


### PR DESCRIPTION
Set HL7 Finland as the publisher.
Set Finland as the jurisdiction.
Set a unique canonical name.
Add a creative commons license.
Add dependency on IPA.