### PR TITLE
Use fhir.fi address as the canonical url for now

### DIFF
--- a/ig.ini
+++ b/ig.ini
@@ -1,3 +1,3 @@
 [IG]
-ig = fsh-generated/resources/ImplementationGuide-finnish-base-profiles.json
-template = fhir.base.template#current
+ig = fsh-generated/resources/ImplementationGuide-fi.fhir.base.json
+template = hl7.fhir.template#current

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -4,7 +4,7 @@
 # │  see: https://fshschool.org/docs/sushi/configuration/.                                         │
 # ╰────────────────────────────────────────────────────────────────────────────────────────────────╯
 id: finnish-base-profiles
-canonical: http://hl7.fi/fhir/finnish-base-profiles
+canonical: http://fhir.fi/finnish-base-profiles
 name: FinnishBaseProfiles
 title: Finnish Base Profiles
 description: A core set of FHIR resources profiled for use in Finland, published and maintained by HL7 Finland

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -3,7 +3,7 @@
 # │  used properties are included. For a list of all supported properties and their functions,     │
 # │  see: https://fshschool.org/docs/sushi/configuration/.                                         │
 # ╰────────────────────────────────────────────────────────────────────────────────────────────────╯
-id: finnish-base-profiles
+id: fi.fhir.base
 canonical: http://fhir.fi/finnish-base-profiles
 name: FinnishBaseProfiles
 title: Finnish Base Profiles


### PR DESCRIPTION
This ensures the links work in the pre-published version. We'll change this for the actual build.