### PR TITLE
Fix template

### DIFF
--- a/ig.ini
+++ b/ig.ini
@@ -1,3 +1,3 @@
 [IG]
 ig = fsh-generated/resources/ImplementationGuide-fi.fhir.base.json
-template = hl7.fhir.template#current
+template = fhir.base.template#current


### PR DESCRIPTION
We cannot use the official HL7 template, at least not yet. The `fi` realm has not been registered.