### PR TITLE
Use release label ci-build

### DIFF
--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -12,7 +12,7 @@ status: draft # draft | active | retired | unknown
 version: 0.1.0
 fhirVersion: 4.0.1 # https://www.hl7.org/fhir/valueset-FHIR-version.html
 copyrightYear: 2022+
-releaseLabel: draft # ci-build | draft | qa-preview | ballot | trial-use | release | update | normative+trial-use
+releaseLabel: ci-build # ci-build | draft | qa-preview | ballot | trial-use | release | update | normative+trial-use
 license: CC0-1.0 # https://www.hl7.org/fhir/valueset-spdx-license.html
 jurisdiction: urn:iso:std:iso:3166#FI "Finland" # https://www.hl7.org/fhir/valueset-jurisdiction.html
 publisher:


### PR DESCRIPTION
This is the appropriate one in this phase of the IG creation, and for this automatically generated version.

We can (and should and will) maintain separate release labels in branches where we publish official versions, hopefully in the `http://hl7.fi` domain. There, we may publish a draft version, then let's change to `ballot`. Once we publish a version for ballot, let's change to `ballot`. And when we publish the first version, change to `trial-use`.