### PR TITLE
Restore full name for links to the GitHub repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The profiles will be based on R4, [FHIR 4.0.1](http://hl7.org/fhir/R4/).
 
 ## Published Snapshot
 
-The working version of the IG is published at https://fhir.fi/fi-base-profiles/.
+The working version of the IG is published at https://fhir.fi/finnish-base-profiles/.
 
 ## Companion Specifications
 

--- a/input/includes/fragment-footer.html
+++ b/input/includes/fragment-footer.html
@@ -7,5 +7,5 @@ Links: <a style="color: var(--footer-hyperlink-text-color)" href="{{site.data.in
   {%- endfor -%}
   | <a style="color: var(--footer-hyperlink-text-color)" href="history.html">Version History</a>
   | <a rel="license" href="{{site.data.fhir.path}}license.html"><img style="border-style: none;" alt="CC0-1.0" src="cc0.png"/></a>
-  | <a style="color: var(--footer-hyperlink-text-color)" href="https://github.com/fhir-fi/fi-base-profiles">Source</a>
-  | <a style="color: var(--footer-hyperlink-text-color)" href="https://github.com/fhir-fi/fi-base-profiles/issues/new">Propose a change</a>
+  | <a style="color: var(--footer-hyperlink-text-color)" href="https://github.com/fhir-fi/finnish-base-profiles">Source</a>
+  | <a style="color: var(--footer-hyperlink-text-color)" href="https://github.com/fhir-fi/finnish-base-profiles/issues/new">Propose a change</a>

--- a/input/pagecontent/index.md
+++ b/input/pagecontent/index.md
@@ -167,7 +167,7 @@ better. Please do be in touch in one of the ways listed below.
 #### Open an Issue in GitHub
 
 The source code of this implementation guide is maintained in a
-[publicly accessible repository](https://github.com/fhir-fi/fi-base-profiles) in GitHub.
+[publicly accessible repository](https://github.com/fhir-fi/finnish-base-profiles) in GitHub.
 Issues opened in that GitHub repo are very welcome. They help the team pick up any proposed changes
 or additions and to discuss them publicly.
 

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -3,12 +3,12 @@
 # │  supported properties, see: https://fshschool.org/sushi/configuration/                         │
 # ╰────────────────────────────────────────────────────────────────────────────────────────────────╯
 id: fi.fhir.base
-canonical: http://fhir.fi/fi-base-profiles
-name: FiBaseProfiles
-title: FI Base Profiles
+canonical: http://fhir.fi/finnish-base-profiles
+name: FinnishBaseProfiles
+title: Finnish Base Profiles
 description: A core set of FHIR resources profiled for use in Finland, published and maintained by HL7 Finland
 status: draft # draft | active | retired | unknown
-version: 0.2.0
+version: 0.2.1
 fhirVersion: 4.0.1 # https://www.hl7.org/fhir/valueset-FHIR-version.html
 copyrightYear: 2022+
 releaseLabel: ci-build # ci-build | draft | qa-preview | ballot | trial-use | release | update | normative+trial-use


### PR DESCRIPTION
The commit fce2a576f34dcb0868d221e3183f970368254928 was a bit too eager...