### PR TITLE
Editorial changes

### DIFF
--- a/input/pagecontent/downloads.md
+++ b/input/pagecontent/downloads.md
@@ -25,7 +25,7 @@ Profiles, valuesets, and other definitions included in this IG in different file
 
 Expansions as FHIR Bundle resources:
 * JSON [expansions.json.zip](expansions.json.zip)
-* XML [expansions.xml.zip]()
+* XML [expansions.xml.zip](expansions.xml.zip)
 
 ### Examples
 

--- a/input/pagecontent/index.md
+++ b/input/pagecontent/index.md
@@ -8,7 +8,7 @@ specification.
 The profiles are based on R4, [FHIR 4.0.1](http://hl7.org/fhir/R4/).
 
 <blockquote class="stu-note">
-  <strong>This documentation and set of artefacts are still undergoing development, and they are in
+  <strong>This documentation and set of artifacts are still undergoing development, and they are in
   DRAFT mode.</strong> The working group of HL7 Finland and the different interested parties are
   working on this specification. This is a DRAFT specification that has not yet been validated by
   the community of users and implementers.


### PR DESCRIPTION
Both are correct spellings, but the IG automation uses artifacts. Let's stick with that.

This text was originally adapted from some other IG...