### PR TITLE
Remove history page from CI builds

### DIFF
--- a/input/pagecontent/history.md
+++ b/input/pagecontent/history.md
@@ -1,5 +1,0 @@
-No versions of this IG have been published yet. This continuous integration build is the first
-version to be created.
-
-It is foreseen that the first version will be balloted (voted on by the HL7 Finland membership) on
-the first quarter of 2023 and published on the second quarter of 2023.

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -156,8 +156,6 @@ pages:
     title: Examples
   downloads.md:
     title: Downloads
-  history.md:
-    title: Version History
 
 parameters: 
   ipa-comparison: "{last}" # "{current}" | "{last}"


### PR DESCRIPTION
Let's only keep and populate this for the published versions. Stored in the `publish` branch.