### PR TITLE
Derive Patient profile from the base FHIR resource

### DIFF
--- a/input/fsh/patient.fsh
+++ b/input/fsh/patient.fsh
@@ -1,5 +1,5 @@
 Profile: FiBasePatient
-Parent: http://hl7.org/fhir/uv/ipa/StructureDefinition/ipa-patient
+Parent: Patient
 Id: fi-base-patient
 Title: "FI Base Patient"
 Description: "This is the Finnish base profile for the Patient resource."

--- a/input/pagecontent/StructureDefinition-fi-base-patient-intro.md
+++ b/input/pagecontent/StructureDefinition-fi-base-patient-intro.md
@@ -4,6 +4,16 @@ The Finnish Core Patient profile is intended to encapsulate the most common and 
 patients in Finnish social and healthcare systems. The profile also defines how to present data
 defined in Finnish legislation. As such the profile should be usable in most Finnish contexts.
 
+<p class="stu-note">The Finnish Base Profiles specification does its best to confom to the <a
+href="https://build.fhir.org/ig/HL7/fhir-ipa/">International Patient Access (IPA)</a>
+specification. All profiles in this implementation guide derive from the IPA profile, if such a
+profile is available - except this Patient profile. This is due to the IPA specification imposing
+cardinality restrictions to Patient.name and Patient.identifier. We specifically don't believe the
+Patient.name should be a mandatory element. The Finnish PHR, for instance, does not include the
+name of the patient in the Patient resource. This is why the Finnish Base Patient profile derives
+from the Patient resource of the main FHIR specification. For additional details, please see the <a
+href="https://jira.hl7.org/browse/FHIR-40451">issue FHIR-40451</a> in HL7 International's Jira.<p>
+
 ### Identifying information
 
 In the context of Finnish national social and healthcare, the


### PR DESCRIPTION
Not the IPA profile.
Especially having the `.name` as a mandatory element makes deriving from it hard.