### PR TITLE
Communicate custodian info by using provenance

### DIFF
--- a/input/fsh/episodeOfCare.fsh
+++ b/input/fsh/episodeOfCare.fsh
@@ -1,0 +1,5 @@
+Profile: FiBaseEpisodeOfCare
+Parent: EpisodeOfCare
+Id: fi-base-episode-of-care
+Title: "FI Base EpisodeOfCare"
+Description: "This is the Finnish base profile for the EpisodeOfCare resource."

--- a/input/fsh/examples/episodeOfCareWithProvenance.fsh
+++ b/input/fsh/examples/episodeOfCareWithProvenance.fsh
@@ -1,0 +1,7 @@
+Instance: EpisodeOfCareExample
+InstanceOf: FiBaseEpisodeOfCare
+Usage: #example
+Description: "Example of episode of care. A provenance links to this."
+* id = "id-for-episode-1"
+* status = #active
+* patient = Reference(Patient/patient-of-municipality)

--- a/input/fsh/examples/provenanceWithCustodianInformation.fsh
+++ b/input/fsh/examples/provenanceWithCustodianInformation.fsh
@@ -1,0 +1,15 @@
+Instance: ProvenanceExample
+InstanceOf: FiBaseProvenance
+Usage: #example
+Description: "Example of provenance that communicates custodian information for an episode of care."
+* id = "id-for-provenance-1"
+* target = Reference(EpisodeOfCare/id-for-episode-1)
+* recorded.value = "2015-02-07T13:28:17.239+02:00"
+* agent[0].who.type = #Organization
+* agent[0].who.identifier.value = "1.2.246.10.32213043.19.0"
+* agent[0].type.coding[0].system = "http://hl7.org/fhir/ValueSet/participation-role-type"
+* agent[0].type.coding[0].code = #custodian
+
+* extension[RegisterTypeCode].valueCoding.system = #urn:oid:1.2.246.537.5.40150.2009
+* extension[RegisterTypeCode].valueCoding.code = #2
+* extension[RegisterTypeCode].valueCoding.display = "Julkinen terveydenhuolto"

--- a/input/fsh/provenance.fsh
+++ b/input/fsh/provenance.fsh
@@ -1,0 +1,20 @@
+Profile: FiBaseProvenance
+Parent: Provenance
+Id: fi-base-provenance
+Title: "FI Base Provenance"
+Description: "This is the Finnish base profile for the Provenance resource."
+
+* extension contains RegisterTypeCode named registerTypeCode 0..1
+* extension contains RegisterSpecifier named registerSpecifier 0..1
+
+Extension: RegisterTypeCode
+Id: register-type-code
+Title: "RegisterTypeCode"
+Description: "Extension RegisterTypeCode. (Required for Kanta Medical Records queries) TODO what is the system?"
+* value[x] only Coding
+
+Extension: RegisterSpecifier
+Id: register-specifier
+Title: "RegisterSpecifier"
+Description: "Extension Rekisterin tarkenne (Required for Kanta Medical Records queries)."
+* value[x] only string

--- a/input/fsh/provenance.fsh
+++ b/input/fsh/provenance.fsh
@@ -16,5 +16,5 @@ Description: "Extension RegisterTypeCode. (Required for Kanta Medical Records qu
 Extension: RegisterSpecifier
 Id: register-specifier
 Title: "RegisterSpecifier"
-Description: "Extension Rekisterin tarkenne (Required for Kanta Medical Records queries)."
+Description: "Extension Register Specifier (Rekisterin tarkenne in finnish) (Required for Kanta Medical Records queries)."
 * value[x] only string

--- a/input/pagecontent/Provenance-id-for-provenance-1-intro.md
+++ b/input/pagecontent/Provenance-id-for-provenance-1-intro.md
@@ -1,0 +1,18 @@
+#### How to communicate Kanta custodian and register information
+
+In this example Kanta custodian information (finnish rekisterinpitäjä) is communicated in agent.
+It refers to organization via identifier, custodian registry is not part of finnish
+SOTE-organization registry (it uses it's own registry 1.2.246.537.6.40174) so it might not exist as
+an organization resource.
+
+RegisterTypeCode requires the registerTypeCode extension. It's a coded value from following code systems:
+
+* 1.2.246.537.5.40150.2009 for healthcare
+* 1.2.246.537.6.1264.201701 for social care
+
+RegisterSpecifier requires the registerSpecifier extension.
+
+#### Use cases
+
+Custodian, register type code and register specifier information is required when making Kanta 
+Medical Records requests.

--- a/input/pagecontent/Provenance-id-for-provenance-1-intro.md
+++ b/input/pagecontent/Provenance-id-for-provenance-1-intro.md
@@ -1,6 +1,6 @@
 #### How to communicate Kanta custodian and register information
 
-In this example Kanta custodian information (finnish rekisterinpitäjä) is communicated in agent.
+In this example Kanta custodian information (Finnish rekisterinpitäjä) is communicated in agent.
 It refers to organization via identifier, custodian registry is not part of finnish
 SOTE-organization registry (it uses it's own registry 1.2.246.537.6.40174) so it might not exist as
 an organization resource.


### PR DESCRIPTION
Adds an example provenance  that communictes custodian and register information. EpisodeOfCare and Provenance resources were missing so they were added.