### PR TITLE
Improvements on condition profile based on feedback

### DIFF
--- a/input/fsh/condition.fsh
+++ b/input/fsh/condition.fsh
@@ -12,7 +12,7 @@ Description: "This is the Finnish base profile for the Condition resource."
 * extension contains ConditionCausedByMedication named conditionCausedByMedication 0..1
 * extension contains ConditionExternalCause named conditionExternalCause 0..1
 * extension contains ConditionCategorizationOfAccident named conditionCategorizationOfAccident 0..1
-* extension contains ExternalCauseOfAdverseEffect named externalCauseOfAdverseEffect 0..1
+* extension contains CauseOfAdverseEffect named causeOfAdverseEffect 0..1
 
 Extension: PrimaryCondition
 Id: condition-primary
@@ -62,10 +62,10 @@ Title: "Categorization of the type of accident"
 Description: "Encoded categorization of the type of accident leading to injury, illness or death."
 * value[x] only Coding
 
-Extension: ExternalCauseOfAdverseEffect
-Id: condition-external-cause-of-adverse-effect
-Title: "External cause of an adverse effect"
-Description: "Encoded information on the external cause of an adverse effect, when involving a procedure or medication"
+Extension: CauseOfAdverseEffect
+Id: condition-cause-of-adverse-effect
+Title: "Cause of an adverse effect"
+Description: "Encoded information on the cause of an adverse effect, when involving a procedure or medication"
 * value[x] only Coding
 
 CodeSystem: FiBaseConditionCategory

--- a/input/fsh/condition.fsh
+++ b/input/fsh/condition.fsh
@@ -5,6 +5,8 @@ Title: "FI Base Condition"
 Description: "This is the Finnish base profile for the Condition resource."
 * ^status = #draft
 
+* subject only Reference(FiBasePatient)
+
 * extension contains PrimaryCondition named primaryCondition 0..1
 * extension contains Permanence named permanence 0..1
 * extension contains PhysicalExcercise named physicalExcercise 0..1

--- a/input/fsh/condition.fsh
+++ b/input/fsh/condition.fsh
@@ -1,4 +1,3 @@
-
 Profile: FiBaseCondition
 Parent: http://hl7.org/fhir/uv/ipa/StructureDefinition/ipa-condition
 Id: fi-base-condition
@@ -6,13 +5,17 @@ Title: "FI Base Condition"
 Description: "This is the Finnish base profile for the Condition resource."
 * ^status = #draft
 
-* extension contains Sport named sport 0..1
+* extension contains PhysicalExcercise named physicalExcercise 0..1
 * extension contains EndocrinologicalDisorder named endocrinologicalDisorder 0..1
+* extension contains ConditionCausedByMedication named conditionCausedByMedication 0..1
+* extension contains ConditionExternalCause named conditionExternalCause 0..1
+* extension contains ConditionCategorizationOfAccident named conditionCategorizationOfAccident 0..1
+* extension contains ExternalCauseOfAdverseEffect named externalCauseOfAdverseEffect 0..1
 
-Extension: Sport
-Id: condition-sport
-Title: "Type of sport in injury"
-Description: "koodilla ilmaistu tieto liikuntalajista, jossa tapaturma on sattunut"
+Extension: PhysicalExcercise
+Id: condition-physical-excercise
+Title: "Type of physical exercise during which injury occurred."
+Description: "Encoded information of the type of physical exercise during which injury occurred."
 * value[x] only Coding
 * valueCoding 1..1
   * system = #urn:oid:1.2.246.537.6.301.201601
@@ -20,36 +23,32 @@ Description: "koodilla ilmaistu tieto liikuntalajista, jossa tapaturma on sattun
 Extension: EndocrinologicalDisorder
 Id: condition-endocrinological-disorder
 Title: "Endocrinological disorder"
-Description: "Code for Endocrinological disorder"
+Description: "Code for Endocrinological disorder."
 * value[x] only Coding
 
-/*
-
-Extension: TODO
-Id: condition-TODO
+Extension: ConditionCausedByMedication
+Id: condition-caused-by-medication
 Title: "Aiheuttajan ATC-koodi"
-Description: "potilaan terveydentilan aiheuttanutta lääkeainetta kuvaava diagnoosikoodin osa"
+Description: "potilaan terveydentilan aiheuttanutta lääkeainetta kuvaava diagnoosikoodi"
 * value[x] only Coding
 
-Extension: TODO
-Id: condition-TODO
-Title: "Diagnoosin ulkoinen syy"
-Description: "Diagnoosin ulkoinen syy"
+Extension: ConditionExternalCause
+Id: condition-external-cause
+Title: "External cause for diagnosis"
+Description: "External cause for diagnosis."
 * value[x] only Coding
 
-Extension: TODO
-Id: condition-TODO
-Title: "Diagnoosin tapaturmatyyppi"
-Description: "koodilla ilmaistu tieto vamman, sairauden tai kuoleman aiheuttaneen tapaturman tyypistä"
+Extension: ConditionCategorizationOfAccident
+Id: condition-categorization-of-accident
+Title: "Categorization of the type of accident"
+Description: "Encoded categorization of the type of accident leading to injury, illness or death."
 * value[x] only Coding
 
-Extension: TODO
-Id: condition-TODO
-Title: "Haittavaikutuksen aiheuttaja"
-Description: "koodilla ilmaistu tieto haittavaikutuksen ulkoisesta syystä silloin, kun syynä on toimenpide tai lääke"
+Extension: ExternalCauseOfAdverseEffect
+Id: condition-external-cause-of-adverse-effect
+Title: "External cause of an adverse effect"
+Description: "Encoded information on the external cause of an adverse effect, when involving a procedure or medication"
 * value[x] only Coding
-
-  */
 
 CodeSystem: FiBaseConditionCategory
 Id: fi-base-condition-category

--- a/input/fsh/condition.fsh
+++ b/input/fsh/condition.fsh
@@ -5,12 +5,30 @@ Title: "FI Base Condition"
 Description: "This is the Finnish base profile for the Condition resource."
 * ^status = #draft
 
+* extension contains PrimaryCondition named primaryCondition 0..1
+* extension contains Permanence named permanence 0..1
 * extension contains PhysicalExcercise named physicalExcercise 0..1
 * extension contains EndocrinologicalDisorder named endocrinologicalDisorder 0..1
 * extension contains ConditionCausedByMedication named conditionCausedByMedication 0..1
 * extension contains ConditionExternalCause named conditionExternalCause 0..1
 * extension contains ConditionCategorizationOfAccident named conditionCategorizationOfAccident 0..1
 * extension contains ExternalCauseOfAdverseEffect named externalCauseOfAdverseEffect 0..1
+
+Extension: PrimaryCondition
+Id: condition-primary
+Title: "Primary condition for encounter"
+Description: "Encoded information of whether this is the primary/main condition for encounter."
+* value[x] only Coding
+* valueCoding 1..1
+  * system = #urn:oid:1.2.246.537.5.40005.2003
+
+Extension: Permanence
+Id: condition-permanence
+Title: "Permanence of condition"
+Description: "Encoded information of whether this is the permanent."
+* value[x] only Coding
+* valueCoding 1..1
+  * system = #urn:oid:1.2.246.537.5.40003.2003
 
 Extension: PhysicalExcercise
 Id: condition-physical-excercise

--- a/input/fsh/condition.fsh
+++ b/input/fsh/condition.fsh
@@ -46,8 +46,8 @@ Description: "Code for Endocrinological disorder."
 
 Extension: ConditionCausedByMedication
 Id: condition-caused-by-medication
-Title: "Aiheuttajan ATC-koodi"
-Description: "potilaan terveydentilan aiheuttanutta lääkeainetta kuvaava diagnoosikoodi"
+Title: "Medication that caused this condition"
+Description: "Encoded information of medication that caused this condition. Uses ATC-coding."
 * value[x] only Coding
 
 Extension: ConditionExternalCause

--- a/input/fsh/examples/diagnosisAdverseEffect.fsh
+++ b/input/fsh/examples/diagnosisAdverseEffect.fsh
@@ -11,13 +11,15 @@ Usage: #example
 * category[1].coding.code = #encounter-diagnosis
 
 * subject = Reference(PatientOfMunicipality)
-* code.coding.system = #1.2.246.537.6.1.1999
+* code.coding.system = #urn:oid:1.2.246.537.6.1.1999
 * code.coding.code = #T81.9
 * code.coding.display = "Määrittämätön toimenpidekomplikaatio"
 * code.text = "Määrittämätön toimenpidekomplikaatio"
 
 * onsetDateTime = "2023-01-05T02:06:24+03:00"
-* clinicalStatus = #active
+
+* clinicalStatus.coding.code = #active
+* clinicalStatus.coding.system = #http://terminology.hl7.org/CodeSystem/condition-clinical
 
 * extension[PrimaryCondition].valueCoding.system = #urn:oid:1.2.246.537.5.40005.2003
 * extension[PrimaryCondition].valueCoding.code = #SIVU
@@ -27,10 +29,10 @@ Usage: #example
 * extension[Permanence].valueCoding.code = #KER
 * extension[Permanence].valueCoding.display = "Kertaluonteinen"
 
-* extension[ConditionExternalCause].valueCoding.system = #1.2.246.537.6.1.1999
+* extension[ConditionExternalCause].valueCoding.system = #urn:oid:1.2.246.537.6.1.1999
 * extension[ConditionExternalCause].valueCoding.code = #Y60.0
 * extension[ConditionExternalCause].valueCoding.display = "Leikkauksen yhteydessä vahingossa syntynyt haava, punktio, perforaatio tai verenvuoto"
 
-* extension[CauseOfAdverseEffect].valueCoding.system = #1.2.246.537.6.2.2007
+* extension[CauseOfAdverseEffect].valueCoding.system = #urn:oid:1.2.246.537.6.2.2007
 * extension[CauseOfAdverseEffect].valueCoding.code = #JAB10
 * extension[CauseOfAdverseEffect].valueCoding.display = "Nivustyrän korjaus"

--- a/input/fsh/examples/diagnosisAdverseEffect.fsh
+++ b/input/fsh/examples/diagnosisAdverseEffect.fsh
@@ -1,0 +1,36 @@
+Instance: DiagnosisAdverseEffect
+InstanceOf: FiBaseCondition
+Title: "Condition - an example diagnosis with an adverse effect."
+Description: "An example of a diagnosis using the FiBaseCondition pofile. This diagnosis demonstrates a case that has an adverse effect."
+Usage: #example
+* id = "id-for-diagnosis-3"
+* category[0].coding.system = #https://hl7.fi/fhir/finnish-base-profiles/CodeSystem/fi-base-condition-category
+* category[0].coding.code = #reason-for-visit
+
+* category[1].coding.system = #http://terminology.hl7.org/CodeSystem/condition-category
+* category[1].coding.code = #encounter-diagnosis
+
+* subject = Reference(PatientOfMunicipality)
+* code.coding.system = #1.2.246.537.6.1.1999
+* code.coding.code = #T81.9
+* code.coding.display = "Määrittämätön toimenpidekomplikaatio"
+* code.text = "Määrittämätön toimenpidekomplikaatio"
+
+* onsetDateTime = "2023-01-05T02:06:24+03:00"
+* clinicalStatus = #active
+
+* extension[PrimaryCondition].valueCoding.system = #urn:oid:1.2.246.537.5.40005.2003
+* extension[PrimaryCondition].valueCoding.code = #SIVU
+* extension[PrimaryCondition].valueCoding.display = "Sivudiagnoosi tai toissijainen toimenpide"
+
+* extension[Permanence].valueCoding.system = #urn:oid:1.2.246.537.5.40003.2003
+* extension[Permanence].valueCoding.code = #KER
+* extension[Permanence].valueCoding.display = "Kertaluonteinen"
+
+* extension[ConditionExternalCause].valueCoding.system = #1.2.246.537.6.1.1999
+* extension[ConditionExternalCause].valueCoding.code = #Y60.0
+* extension[ConditionExternalCause].valueCoding.display = "Leikkauksen yhteydessä vahingossa syntynyt haava, punktio, perforaatio tai verenvuoto"
+
+* extension[CauseOfAdverseEffect].valueCoding.system = #1.2.246.537.6.2.2007
+* extension[CauseOfAdverseEffect].valueCoding.code = #JAB10
+* extension[CauseOfAdverseEffect].valueCoding.display = "Nivustyrän korjaus"

--- a/input/fsh/examples/diagnosisMedicationAccident.fsh
+++ b/input/fsh/examples/diagnosisMedicationAccident.fsh
@@ -1,0 +1,40 @@
+Instance: DiagnosisMedicationAccident
+InstanceOf: FiBaseCondition
+Title: "Condition - an example diagnosis with external cause, accident and medication information."
+Description: "An example of a diagnosis using the FiBaseCondition pofile. This diagnosis demonstrates a case that has external cause, accident and medication information."
+Usage: #example
+* id = "id-for-diagnosis-2"
+* category[0].coding.system = #https://hl7.fi/fhir/finnish-base-profiles/CodeSystem/fi-base-condition-category
+* category[0].coding.code = #reason-for-visit
+
+* category[1].coding.system = #http://terminology.hl7.org/CodeSystem/condition-category
+* category[1].coding.code = #encounter-diagnosis
+
+* subject = Reference(PatientOfMunicipality)
+* code.coding.system = #1.2.246.537.6.1.1999
+* code.coding.code = #T88.7
+* code.coding.display = "Määrittämätön lääkeaineen epäedullinen vaikutus"
+* code.text = "Määrittämätön lääkeaineen epäedullinen vaikutus"
+
+* onsetDateTime = "2023-01-05T02:06:24+03:00"
+* clinicalStatus = #active
+
+* extension[PrimaryCondition].valueCoding.system = #urn:oid:1.2.246.537.5.40005.2003
+* extension[PrimaryCondition].valueCoding.code = #PAA
+* extension[PrimaryCondition].valueCoding.display = "Päädiagnoosi tai päätoimenpide"
+
+* extension[Permanence].valueCoding.system = #urn:oid:1.2.246.537.5.40003.2003
+* extension[Permanence].valueCoding.code = #KER
+* extension[Permanence].valueCoding.display = "Kertaluonteinen"
+
+* extension[ConditionExternalCause].valueCoding.system = #1.2.246.537.6.1.1999
+* extension[ConditionExternalCause].valueCoding.code = #X44
+* extension[ConditionExternalCause].valueCoding.display = "Lääkkeiden tai lääkkeenomaisten aineiden aiheuttama myrkytystapaturma tai muu altistuminen"
+
+* extension[ConditionCategorizationOfAccident].valueCoding.system = #1.2.246.537.6.1.1999
+* extension[ConditionCategorizationOfAccident].valueCoding.code = #Y95.0
+* extension[ConditionCategorizationOfAccident].valueCoding.display = "Tapaturma sairaalassa tai sairaalaoloihin liittyvä ulkoinen tekijä"
+
+* extension[ConditionCausedByMedication].valueCoding.system = #1.2.246.537.6.32.2007
+* extension[ConditionCausedByMedication].valueCoding.code = #M01AE01
+* extension[ConditionCausedByMedication].valueCoding.display = "BURANA 200 mg tabletti, kalvopäällysteinen"

--- a/input/fsh/examples/diagnosisMedicationAccident.fsh
+++ b/input/fsh/examples/diagnosisMedicationAccident.fsh
@@ -11,13 +11,15 @@ Usage: #example
 * category[1].coding.code = #encounter-diagnosis
 
 * subject = Reference(PatientOfMunicipality)
-* code.coding.system = #1.2.246.537.6.1.1999
+* code.coding.system = #urn:oid:1.2.246.537.6.1.1999
 * code.coding.code = #T88.7
 * code.coding.display = "Määrittämätön lääkeaineen epäedullinen vaikutus"
 * code.text = "Määrittämätön lääkeaineen epäedullinen vaikutus"
 
 * onsetDateTime = "2023-01-05T02:06:24+03:00"
-* clinicalStatus = #active
+
+* clinicalStatus.coding.code = #active
+* clinicalStatus.coding.system = #http://terminology.hl7.org/CodeSystem/condition-clinical
 
 * extension[PrimaryCondition].valueCoding.system = #urn:oid:1.2.246.537.5.40005.2003
 * extension[PrimaryCondition].valueCoding.code = #PAA
@@ -27,14 +29,14 @@ Usage: #example
 * extension[Permanence].valueCoding.code = #KER
 * extension[Permanence].valueCoding.display = "Kertaluonteinen"
 
-* extension[ConditionExternalCause].valueCoding.system = #1.2.246.537.6.1.1999
+* extension[ConditionExternalCause].valueCoding.system = #urn:oid:1.2.246.537.6.1.1999
 * extension[ConditionExternalCause].valueCoding.code = #X44
 * extension[ConditionExternalCause].valueCoding.display = "Lääkkeiden tai lääkkeenomaisten aineiden aiheuttama myrkytystapaturma tai muu altistuminen"
 
-* extension[ConditionCategorizationOfAccident].valueCoding.system = #1.2.246.537.6.1.1999
+* extension[ConditionCategorizationOfAccident].valueCoding.system = #urn:oid:1.2.246.537.6.1.1999
 * extension[ConditionCategorizationOfAccident].valueCoding.code = #Y95.0
 * extension[ConditionCategorizationOfAccident].valueCoding.display = "Tapaturma sairaalassa tai sairaalaoloihin liittyvä ulkoinen tekijä"
 
-* extension[ConditionCausedByMedication].valueCoding.system = #1.2.246.537.6.32.2007
+* extension[ConditionCausedByMedication].valueCoding.system = #urn:oid:1.2.246.537.6.32.2007
 * extension[ConditionCausedByMedication].valueCoding.code = #M01AE01
 * extension[ConditionCausedByMedication].valueCoding.display = "BURANA 200 mg tabletti, kalvopäällysteinen"

--- a/input/fsh/examples/diagnosisSimple.fsh
+++ b/input/fsh/examples/diagnosisSimple.fsh
@@ -10,14 +10,6 @@ Usage: #example
 * category[1].coding.system = #http://terminology.hl7.org/CodeSystem/condition-category
 * category[1].coding.code = #encounter-diagnosis
 
-* category[2].coding.system = #urn:oid:1.2.246.537.5.40005.2003
-* category[2].coding.code = #PAA
-* category[2].coding.display = "Päädiagnoosi tai päätoimenpide"
-
-* category[3].coding.system = #urn:1.2.246.537.5.40003.2003
-* category[3].coding.code = #PYS
-* category[3].coding.display = "Pysyväisluonteinen"
-
 * subject = Reference(PatientOfMunicipality)
 * code.coding.system = #1.2.246.537.6.1.1999
 * code.coding.code = #H36.03
@@ -30,3 +22,11 @@ Usage: #example
 
 * onsetDateTime = "2023-01-05T02:06:24+03:00"
 * clinicalStatus = #active
+
+* extension[PrimaryCondition].valueCoding.system = #urn:oid:1.2.246.537.5.40005.2003
+* extension[PrimaryCondition].valueCoding.code = #PAA
+* extension[PrimaryCondition].valueCoding.display = "Päädiagnoosi tai päätoimenpide"
+
+* extension[Permanence].valueCoding.system = #urn:oid:1.2.246.537.5.40003.2003
+* extension[Permanence].valueCoding.code = #PYS
+* extension[Permanence].valueCoding.display = "Pysyväisluonteinen"

--- a/input/fsh/examples/diagnosisSimple.fsh
+++ b/input/fsh/examples/diagnosisSimple.fsh
@@ -11,17 +11,19 @@ Usage: #example
 * category[1].coding.code = #encounter-diagnosis
 
 * subject = Reference(PatientOfMunicipality)
-* code.coding.system = #1.2.246.537.6.1.1999
+* code.coding.system = #urn:oid:1.2.246.537.6.1.1999
 * code.coding.code = #H36.03
 * code.coding.display = "Proliferatiivinen diabeettinen retinopatia"
 * code.text = "Proliferatiivinen diabeettinen retinopatia, vasen, laserhoidettu"
 
-* evidence[0].code.coding.system = #1.2.246.537.6.1.1999
+* evidence[0].code.coding.system = #urn:oid:1.2.246.537.6.1.1999
 * evidence[0].code.coding.code = #E11.3
 * evidence[0].code.coding.display = "Aikuistyypin diabetes diabeteksen silmäkomplikaatiot"
 
 * onsetDateTime = "2023-01-05T02:06:24+03:00"
-* clinicalStatus = #active
+
+* clinicalStatus.coding.code = #active
+* clinicalStatus.coding.system = #http://terminology.hl7.org/CodeSystem/condition-clinical
 
 * extension[PrimaryCondition].valueCoding.system = #urn:oid:1.2.246.537.5.40005.2003
 * extension[PrimaryCondition].valueCoding.code = #PAA

--- a/input/pagecontent/StructureDefinition-fi-base-condition-intro.md
+++ b/input/pagecontent/StructureDefinition-fi-base-condition-intro.md
@@ -106,17 +106,6 @@ When `asserter` references a Practitioner, it can provide information for codeId
 in THL specification. When `asserter` references a PractitionerRole, it can provide information for
 both codeId 11: Toteajan nimi and codeId 19: Toteajan palveluyksikkö.
 
-#### Is not authored by a medical doctor (*Käyntisyy*)
-
-Some conditions are very much like diagnosis but the asserter is not a medical doctor. THL
-specification identifies these as *käyntisyy*.
-
-Extension `isNotAuthoredByMedicalDoctor` with value `true` MUST be used when condition is a *käyntisyy*.
-It MAY be used with value `false` on medical doctor asserted diagnosis, but absence of this extension
-SHALL be interpreted as not being a *käyntisyy*.
-
-
-
 #### Type of sport in injury cases
 
 Extension `sport`.

--- a/input/pagecontent/StructureDefinition-fi-base-condition-intro.md
+++ b/input/pagecontent/StructureDefinition-fi-base-condition-intro.md
@@ -11,7 +11,7 @@ Use cases:
 * Reason given by patient for requesting/acquiring healthcare service. Finnish *tulosyy*
 * Other usages for various needs
 
-### Reasons for visit (Diagnosis -based conditions and Finnish *käyntisyy*)
+#### Reasons for visit (Diagnosis -based conditions and Finnish *käyntisyy*)
 
 Reason for visit may be a diagnosis asserted by a clinician / medical doctor or some other reason
 for visit that is asserted by an nurse or some other healthcare professional.
@@ -37,14 +37,14 @@ Categories match to THL specification in following way:
 * when `encounter-diagnosis` is not present --> This is a *käyntisyy*
     * In THL specification, codeId 23: Käyntisyy has value True
 
-#### Diagnosis Code Systems
+##### Diagnosis Code Systems
 
 When using [Finnish ICD-10](https://koodistopalvelu.kanta.fi/codeserver/pages/classification-view-page.xhtml?classificationKey=23&versionKey=58)
 it's usage has special rules. These are described below. For reference and detailed specifications,
 see [Potilastiedon arkiston Kertomus ja lomakkeet](https://www.kanta.fi/jarjestelmakehittajat/kertomus-ja-lomakkeet)
 version 5.11 or later.
 
-#### Diagnosis code (reason)
+##### Diagnosis code (reason)
 
 `code` SHALL only contain the reason code.
 
@@ -85,7 +85,7 @@ repetitions expressing the same information in two code systems):
   }
 ```
 
-#### Symptom code
+##### Symptom code
 
 Symptom code SHOULD be communicated via `evidence`.
 
@@ -116,14 +116,14 @@ For example:
 
 In THL specification, this data is codeId 26: Diagnoosin tai käyntisyyn oirekoodi.
 
-#### When name differs from code.display
+##### When name differs from code.display
 
 Medical doctor may make some adjustments to the name of the diagnosis. `code.display` MUST be the
 original name from the codesystem and `code.text` MAY contain adjusted name for the diagnosis.
 
 In THL specification, this data is codeId 21: Diagnoosin tai käyntisyyn nimi.
 
-#### Primary/main diagnosis (or käyntisyy)
+##### Primary/main diagnosis (or käyntisyy)
 
 Extension `primaryCondition` is used to express whether this is the primary/main condition for encounter.
 
@@ -131,7 +131,7 @@ Extension is a code from terminology "AR/YDIN - Diagnoosin /toimenpiteen ensisij
 
 In THL specification, this data is codeId 2: Diagnoosin tai käyntisyyn ensisijaisuus.
 
-#### Permanence (finnish "pysyvyys")
+##### Permanence (finnish "pysyvyys")
 
 Extension `permanence` is used to express the condition is permanent or not.
 
@@ -142,19 +142,19 @@ clinicalStatus codes (doing so would redefine clinicalStatus).
 
 In THL specification, this data is codeId 8: Diagnoosin pysyvyys.
 
-#### Onset
+##### Onset
 
 Standard `onset` SHOULD be used.
 
 In THL specification, this data is codeId 12: Diagnoosin tai käyntisyyn toteamispäivä.
 
-#### Abatement
+##### Abatement
 
 Standard `abatement` MAY be used.
 
 In THL specification, this data is codeId 16: Diagnoosin päättymispäivä.
 
-#### Asserter
+##### Asserter
 
 Standard `asserter` MAY be used.
 
@@ -162,7 +162,7 @@ When `asserter` references a Practitioner, it can provide information for codeId
 in THL specification. When `asserter` references a PractitionerRole, it can provide information for
 both codeId 11: Toteajan nimi and codeId 19: Toteajan palveluyksikkö.
 
-#### Type of physical exercise during which injury occurred
+##### Type of physical exercise during which injury occurred
 
 Extension `physicalExcercise`.
 
@@ -170,7 +170,7 @@ TODO add example.
 
 In THL specification, this data is codeId: 24 Tapaturman liikuntalaji.
 
-#### Endocrinological disorder
+##### Endocrinological disorder
 
 Extension `endocrinologicalDisorder`.
 
@@ -178,31 +178,31 @@ TODO add example.
 
 In THL specification, this data is codeId: 27 Endokrinologisen häiriön koodi.
 
-#### Medication that caused this condition
+##### Medication that caused this condition
 
 Extension `conditionCausedByMedication`  
 
 In THL specification, this data is codeId: 28 Aiheuttajan ATC-koodi
 
-#### External cause for diagnosis
+##### External cause for diagnosis
 
 Extension `conditionExternalCause`
 
 In THL specification, this data is codeId: 3 Diagnoosin ulkoinen syy
 
-#### Categorization of the type of accident
+##### Categorization of the type of accident
 
 Extension `conditionCategorizationOfAccident`
 
 In THL specification, this data is codeId: 4 Diagnoosin tapaturmatyyppi
 
-#### Cause of an adverse effect
+##### Cause of an adverse effect
 
 Extension `causeOfAdverseEffect`
 
 In THL specification, this data is codeId: 5 Haittavaikutuksen aiheuttaja
 
-#### Further development needs
+##### Further development needs
 
 Finnish diagnosis has some data that is not yet modeled in this profile. There is more modeling and
 mapping work to be done. Following list contains most relevant parts that need work:

--- a/input/pagecontent/StructureDefinition-fi-base-condition-intro.md
+++ b/input/pagecontent/StructureDefinition-fi-base-condition-intro.md
@@ -200,8 +200,6 @@ In THL specification, this data is codeId: 4 Diagnoosin tapaturmatyyppi
 
 Extension `causeOfAdverseEffect`
 
-TODO  example
-
 In THL specification, this data is codeId: 5 Haittavaikutuksen aiheuttaja
 
 #### Further development needs

--- a/input/pagecontent/StructureDefinition-fi-base-condition-intro.md
+++ b/input/pagecontent/StructureDefinition-fi-base-condition-intro.md
@@ -82,7 +82,7 @@ repetitions expressing the same information in two code systems):
       }
     ],
     "text" : "..."
-  },
+  }
 ```
 
 #### Symptom code
@@ -216,6 +216,7 @@ mapping work to be done. Following list contains most relevant parts that need w
 * THL Tietosisältö 20 Diagnoosin päättymisen toteajan palveluyksikkö
 * THL Tietosisältö 22 Episodin nimi
 * THL Tietosisältö 7 Diagnoosin tai käyntisyyn varmuusaste
+    * map to [verificationStatus codes](https://hl7.org/fhir/R4/valueset-condition-ver-status.html)?
 * THL Tietosisältö 9 Diagnoosin tai käyntisyyn episoditunnus
 
 #### Links

--- a/input/pagecontent/StructureDefinition-fi-base-condition-intro.md
+++ b/input/pagecontent/StructureDefinition-fi-base-condition-intro.md
@@ -7,8 +7,9 @@ href="#further-development-needs">further development needs</a> below.</p>
 
 Use cases:
 
-* Diagnosis -based conditions and Finnish Kayntisyy
-* Other usages?
+* Diagnosis -based conditions and Finnish *kayntisyy*, asserted by a healthcare professional
+* Reason given by patient for requesting/acquiring healthcare service. Finnish *tulosyy*
+* Other usages for various needs
 
 ### Reasons for visit (Diagnosis -based conditions and Finnish *käyntisyy*)
 
@@ -18,7 +19,7 @@ for visit that is asserted by an nurse or some other healthcare professional.
 To identify that a condition resource is a reason for visit, it MUST contain `category` code
 `reason-for-visit`.
 
-A reason for visit condition needs to be further categorized to make the distinction between 
+A reason for visit condition needs to be further categorized to make the distinction between
 clinician asserted diagnosis and other *käyntisyy* conditions. When condition is a clinician
 asserted diagnosis it MUST contain another `category` code `encounter-diagnosis`. When condition
 is not asserted by a clincian it MUST NOT contain `encounter-diagnosis` category code.
@@ -55,6 +56,11 @@ In THL specification, this data is codeId 1: Diagnoosi.
 In THL specification, there is another codeId 6: "ICD-10 -vastaavuuskoodi ICPC-koodille". This MAY be
 in `code` (it's the same code, but coded in another code system, so repetition of `code` is ok).
 Other codes, like symptom and accident type SHOULD NOT be repetitions of `code`.
+
+More than one code may be used in `code`. Currently ICD-10, ICPC2 are supported by THL, in near
+future ICD-11, SNOMED and ORPHA will become supported too). Additional codes may be expressed by
+repeating coding. Other codes like sympton SHOULD not be communicated via `code`, repetitions
+should represent the same concept (see [CodeableConcept datatype specification](https://www.hl7.org/fhir/datatypes.html#CodeableConcept)).
 
 #### Symptom code
 
@@ -106,9 +112,9 @@ When `asserter` references a Practitioner, it can provide information for codeId
 in THL specification. When `asserter` references a PractitionerRole, it can provide information for
 both codeId 11: Toteajan nimi and codeId 19: Toteajan palveluyksikkö.
 
-#### Type of sport in injury cases
+#### Type of physical exercise during which injury occurred
 
-Extension `sport`.
+Extension `physicalExcercise`.
 
 TODO add example.
 
@@ -124,23 +130,26 @@ In THL specification, this data is codeId: 27 Endokrinologisen häiriön koodi.
 
 #### 28 Aiheuttajan ATC-koodi
 
-TODO define extension and example
+Extension `conditionCausedByMedication`  
+
+TODO example
 
 #### 3 Diagnoosin ulkoinen syy
 
-TODO define extension and example
+Extension `conditionExternalCause`
+
+TODO  example
 
 #### 4 Diagnoosin tapaturmatyyppi
 
-TODO define extension and example
+Extension `conditionCategorizationOfAccident`
+TODO d example
 
 #### 5 Haittavaikutuksen aiheuttaja
 
-TODO define extension and example
+Extension `externalCauseOfAdverseEffect`
 
-#### Other category usages
-
-`category` SHOULD also contain the standard `encounter-diagnosis`.
+TODO  example
 
 #### Further development needs
 

--- a/input/pagecontent/StructureDefinition-fi-base-condition-intro.md
+++ b/input/pagecontent/StructureDefinition-fi-base-condition-intro.md
@@ -182,15 +182,11 @@ In THL specification, this data is codeId: 27 Endokrinologisen häiriön koodi.
 
 Extension `conditionCausedByMedication`  
 
-TODO example
-
 In THL specification, this data is codeId: 28 Aiheuttajan ATC-koodi
 
 #### External cause for diagnosis
 
 Extension `conditionExternalCause`
-
-TODO  example
 
 In THL specification, this data is codeId: 3 Diagnoosin ulkoinen syy
 
@@ -198,13 +194,11 @@ In THL specification, this data is codeId: 3 Diagnoosin ulkoinen syy
 
 Extension `conditionCategorizationOfAccident`
 
-TODO  example
-
 In THL specification, this data is codeId: 4 Diagnoosin tapaturmatyyppi
 
-#### External cause of an adverse effect
+#### Cause of an adverse effect
 
-Extension `externalCauseOfAdverseEffect`
+Extension `causeOfAdverseEffect`
 
 TODO  example
 

--- a/input/pagecontent/StructureDefinition-fi-base-condition-intro.md
+++ b/input/pagecontent/StructureDefinition-fi-base-condition-intro.md
@@ -125,13 +125,20 @@ In THL specification, this data is codeId 21: Diagnoosin tai käyntisyyn nimi.
 
 #### Primary/main diagnosis (or käyntisyy)
 
-Use `category` code from "AR/YDIN - Diagnoosin /toimenpiteen ensisijaisuus" (1.2.246.537.5.40005.2003).
+Extension `primaryCondition` is used to express whether this is the primary/main condition for encounter.
+
+Extension is a code from terminology "AR/YDIN - Diagnoosin /toimenpiteen ensisijaisuus" (1.2.246.537.5.40005.2003).
 
 In THL specification, this data is codeId 2: Diagnoosin tai käyntisyyn ensisijaisuus.
 
 #### Permanence (finnish "pysyvyys")
 
-Use `category` code from  "AR/YDIN - Pysyvyys" versiosta (1.2.246.537.5.40003.2003).
+Extension `permanence` is used to express the condition is permanent or not.
+
+Extension is a code from terminology "AR/YDIN - Pysyvyys" (1.2.246.537.5.40003.2003).
+
+This information has some relation to `clinicalStatus`, but "AR/YDIN - Pysyvyys" can't be mapped to
+clinicalStatus codes (doing so would redefine clinicalStatus).
 
 In THL specification, this data is codeId 8: Diagnoosin pysyvyys.
 

--- a/input/pagecontent/StructureDefinition-fi-base-condition-intro.md
+++ b/input/pagecontent/StructureDefinition-fi-base-condition-intro.md
@@ -41,7 +41,8 @@ Categories match to THL specification in following way:
 
 When using [Finnish ICD-10](https://koodistopalvelu.kanta.fi/codeserver/pages/classification-view-page.xhtml?classificationKey=23&versionKey=58)
 it's usage has special rules. These are described below. For reference and detailed specifications,
-see [Potilastiedon arkiston Kertomus ja lomakkeet](https://www.kanta.fi/jarjestelmakehittajat/kertomus-ja-lomakkeet).
+see [Potilastiedon arkiston Kertomus ja lomakkeet](https://www.kanta.fi/jarjestelmakehittajat/kertomus-ja-lomakkeet)
+version 5.11 or later.
 
 #### Diagnosis code (reason)
 

--- a/input/pagecontent/StructureDefinition-fi-base-condition-intro.md
+++ b/input/pagecontent/StructureDefinition-fi-base-condition-intro.md
@@ -178,28 +178,37 @@ TODO add example.
 
 In THL specification, this data is codeId: 27 Endokrinologisen häiriön koodi.
 
-#### 28 Aiheuttajan ATC-koodi
+#### Medication that caused this condition
 
 Extension `conditionCausedByMedication`  
 
 TODO example
 
-#### 3 Diagnoosin ulkoinen syy
+In THL specification, this data is codeId: 28 Aiheuttajan ATC-koodi
+
+#### External cause for diagnosis
 
 Extension `conditionExternalCause`
 
 TODO  example
 
-#### 4 Diagnoosin tapaturmatyyppi
+In THL specification, this data is codeId: 3 Diagnoosin ulkoinen syy
+
+#### Categorization of the type of accident
 
 Extension `conditionCategorizationOfAccident`
-TODO d example
 
-#### 5 Haittavaikutuksen aiheuttaja
+TODO  example
+
+In THL specification, this data is codeId: 4 Diagnoosin tapaturmatyyppi
+
+#### External cause of an adverse effect
 
 Extension `externalCauseOfAdverseEffect`
 
 TODO  example
+
+In THL specification, this data is codeId: 5 Haittavaikutuksen aiheuttaja
 
 #### Further development needs
 

--- a/input/pagecontent/StructureDefinition-fi-base-condition-intro.md
+++ b/input/pagecontent/StructureDefinition-fi-base-condition-intro.md
@@ -58,10 +58,32 @@ In THL specification, there is another codeId 6: "ICD-10 -vastaavuuskoodi ICPC-k
 in `code` (it's the same code, but coded in another code system, so repetition of `code` is ok).
 Other codes, like symptom and accident type SHOULD NOT be repetitions of `code`.
 
-More than one code may be used in `code`. Currently ICD-10, ICPC2 are supported by THL, in near
-future ICD-11, SNOMED and ORPHA will become supported too). Additional codes may be expressed by
-repeating coding. Other codes like sympton SHOULD not be communicated via `code`, repetitions
-should represent the same concept (see [CodeableConcept datatype specification](https://www.hl7.org/fhir/datatypes.html#CodeableConcept)).
+More than one code may be used in `code` (in `code`'s repetitions of `coding`). `code` itself cannot
+be repeated. Currently ICD-10, ICPC2 are supported by THL, in near future ICD-11, SNOMED and ORPHA
+will become supported too). Additional codes may be expressed by repeating coding. Other codes like
+sympton SHOULD not be communicated via `code`, repetitions should represent the same concept (see
+[CodeableConcept datatype specification](https://www.hl7.org/fhir/datatypes.html#CodeableConcept)).
+
+Here's a valid example of repeating `code.coding` (`code` is not repeating, but `coding` has
+repetitions expressing the same information in two code systems):
+
+``` json
+  "code" : {
+    "coding" : [
+      {
+        "system" : "1.2.246.537.6.1.1999",
+        "code" : "H36.03",
+        "display" : "Proliferatiivinen diabeettinen retinopatia"
+      },
+      {
+        "system" : "1.2.246.537.6.31.2007",
+        "code" : "F83",
+        "display" : "Retinopatia, verkkokalvon rappeuma"
+      }
+    ],
+    "text" : "..."
+  },
+```
 
 #### Symptom code
 
@@ -71,6 +93,26 @@ When using Finnish ICD-10, code MUST NOT contain special characters (`+` after t
 code indicates symptom). Pre-built pairs (like E85.9+I68.0) code . SHALL be broken down to
 constituent parts and the code part indicating symptom (in case of in case of E85.9+I68.0, `Koodi2`
 field) used here.
+
+For example:
+
+``` json
+"evidence" : [
+    {
+      "code" : [
+        {
+          "coding" : [
+            {
+              "system" : "1.2.246.537.6.1.1999",
+              "code" : "E11.3",
+              "display" : "Aikuistyypin diabetes diabeteksen silmäkomplikaatiot"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+```
 
 In THL specification, this data is codeId 26: Diagnoosin tai käyntisyyn oirekoodi.
 


### PR DESCRIPTION
A step forward on mapping national Diagnosis and Käyntisyy specs to Condition profile.

Generally makes the profile more complete. Defines missing extensions and adds pretty extensive examples. Improves language (contains extension renames).

There was conversation about the overuse and maybe even misuse of category for permanence and primary condition. This PR moves this data to extensions. (There's some back-and-forth movement here, initial design had extensions. Expecting more discussion on this topic.)

Patient refers now to FiBasePatient.