### PR TITLE
participant.type fixed

### DIFF
--- a/input/fsh/examples/appointmentGeneralPractitioner.fsh
+++ b/input/fsh/examples/appointmentGeneralPractitioner.fsh
@@ -21,7 +21,7 @@ Description: "Appointment example to general practitioner."
 * participant[+].actor = Reference(PractitionerLicensedPhysician)
 * participant[=].required = #required
 * participant[=].status = #accepted
-* participant[=].type = http://hl7.org/fhir/v3/ParticipationType#PPRF
+* participant[=].type = http://terminology.hl7.org/CodeSystem/v3-ParticipationType#PPRF
 * participant[+].actor = Reference(LocationExample)
 * participant[=].status = #accepted
 * participant[+].actor = Reference(AT-340)


### PR DESCRIPTION
Fixed participant.type url to clean the validation results file. Tried to hide errors regarding extensions but for some reason it didn's work...