### PR TITLE
Add info on sushi install

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,14 +65,16 @@ With the above requirements installed locally, run
 #### On OSX, Linux, or Unix
 
 ``` bash
+npm install -g fsh-sushi
 ./_updatePublisher.sh --yes
 ./_genonce.sh
 ```
 
 #### On Windows
 ```
-./_updatePublisher.bat --yes
-./_genonce.bat
+npm install -g fsh-sushi
+.\_updatePublisher.bat --yes
+.\_genonce.bat
 ```
 
 ### Using Docker


### PR DESCRIPTION
Not sure whether this is the right place, but we need to explain that sushi needs to be installed as an npm package.

Also, fixed command line syntax for Windows.

We could also explain what each of the commands does...