### PR TITLE
Define a security label for patient non-disclosure

### DIFF
--- a/input/fsh/examples/patientWithTurvakielto.fsh
+++ b/input/fsh/examples/patientWithTurvakielto.fsh
@@ -1,0 +1,20 @@
+Instance: PatientWithTurvakielto
+InstanceOf: FiBasePatient
+Title: "Patient - has TURVAKIELTO security label."
+Description: "An example of a FI Base patient that has the TURVAKIELTO security label indicating non-disclosure for personal safety reasons."
+Usage: #example
+* meta.security[0] = SecurityLabelCS#TURVAKIELTO
+* id = "patient-with-turvakielto"
+* identifier[PIC]
+  * use = #official
+  * type = #NNFIN
+  * system = #urn:oid:1.2.246.21
+  * value = "010190-999X"
+* birthDate = "1990-01-01"
+* name
+  * given = "Turva"
+  * family = "Henkilö"
+* active = true
+* extension[MunicipalityCode].valueCoding.system = #urn:oid:1.2.246.537.6.21.2003
+* extension[MunicipalityCode].valueCoding.code = #020
+* extension[MunicipalityCode].valueCoding.display = "Akaa"

--- a/input/fsh/security.fsh
+++ b/input/fsh/security.fsh
@@ -1,0 +1,14 @@
+CodeSystem: SecurityLabelCS
+Id: SecurityLabelCS
+Title: "Finnish CodeSystem for security labels"
+Description: "This is the CodeSystem for security labels in accordance with finnish authorities"
+* ^status = #active
+* ^experimental = false
+* #TURVAKIELTO "Turvakielto"
+"A non-disclosure for personal safety reasons according to DVV."
+
+ValueSet: SecurityLabelVS
+Title: "Finnish ValueSet for security labels in accordance with finnish authorities"
+* ^status = #active
+* ^experimental = false
+* SecurityLabelCS#TURVAKIELTO

--- a/input/pagecontent/StructureDefinition-fi-base-patient-intro.md
+++ b/input/pagecontent/StructureDefinition-fi-base-patient-intro.md
@@ -92,27 +92,10 @@ time of day is not known, the date SHALL be recorded as a date only, without the
 The birth time, when known, SHALL be recorded using the
 [standard extension](http://hl7.org/fhir/extensions/StructureDefinition-patient-birthTime.html).
 
-#### Use of non-disclosure information
+#### Non-disclosure for personal safety
 
-Finnish citizens that have requested name and address protection
-([Non-disclosure for personal safety](https://dvv.fi/en/non-disclosure-for-personal-safety)) are
-labeled with the security label. The preferred way to do this is shown below.
- 
- ```
- <Patient xmlns="http://hl7.org/fhir">
-  <meta>
-    <security>
-      <system value="http://terminology.hl7.org/CodeSystem/v3-Confidentiality"/>
-      <code value="R"/>
-      <display value="Restricted"/>
-    </security>
-  </meta>
-...  [snip] ...
-</Patient>
- ```
-
-Use of this label should be interpreted according to the law, rouhgly meaning that only personnel
-using systems in their work are allowed to see the name and address for the patient.
+DVV may grant a [non-disclosure for personal safety](https://dvv.fi/en/non-disclosure-for-personal-safety),
+this is communicated by `TURVAKIELTO` security label.
 
 #### Presenting guardian information
 


### PR DESCRIPTION
Based on feedback, the standard v3-Confidentiality code was not accurate enough to communicate DVV's non disclosure for persona safety / turvakielto.

Defines a new CodeSystem for finnish security labels and adds TURVAKIELTO to it. Meaning should now be explicit.