### PR TITLE
Reduce ipa dependencies

### DIFF
--- a/input/fsh/codesystems/security.fsh
+++ b/input/fsh/codesystems/security.fsh
@@ -1,7 +1,7 @@
 CodeSystem: SecurityLabelCS
 Id: SecurityLabelCS
 Title: "Finnish CodeSystem for security labels"
-Description: "This is the CodeSystem for security labels in accordance with finnish authorities"
+Description: "This is the CodeSystem for security labels in accordance with finnish authorities."
 * ^status = #active
 * ^experimental = false
 * #TURVAKIELTO "Turvakielto"

--- a/input/fsh/examples/medicationStatementInsulin.fsh
+++ b/input/fsh/examples/medicationStatementInsulin.fsh
@@ -1,0 +1,14 @@
+Instance: MedicationStatementInsulin
+InstanceOf: FiBaseMedicationStatement
+Title: "Simple medication statement example"
+Description: "Patient states they are taking long acting insulin (Lantus), but not the amount."
+Usage: #example
+* id = "medication-statement-insulin"
+* medicationCodeableConcept
+  * coding[0] = http://snomed.info/sct#411529005 "Insulin glargine"
+  * coding[+] = http://www.whocc.no/atc#A10AE04 "insulin glargine"
+  * text = "Insulin glargine (Lantus)"
+* status = #active
+* subject = Reference(PatientOfMunicipality)
+* effectiveDateTime = "2023-07-22"
+* informationSource = Reference(PatientOfMunicipality)

--- a/input/fsh/medication.fsh
+++ b/input/fsh/medication.fsh
@@ -1,8 +1,8 @@
 Profile: FiBaseMedication
-Parent: http://hl7.org/fhir/uv/ipa/StructureDefinition/ipa-medication
+Parent: Medication
 Id: fi-base-medication
 Title: "FI Base Medication"
-Description: "This is the Finnish base profile for the Medication resource."
+Description: "This is the Finnish base profile for the Medication resource for other than patient access use cases."
 * ^status = #draft
 * manufacturer only Reference(FiBaseOrganization)
-* ingredient.itemReference only Reference(Substance or FiBaseMedication)
+* ingredient.itemReference only Reference(Substance or FiBaseMedication or FiBasePatientMedication)

--- a/input/fsh/medicationAdministration.fsh
+++ b/input/fsh/medicationAdministration.fsh
@@ -5,6 +5,7 @@ Title: "FI Base MedicationAdministration"
 Description: "This is the Finnish base profile for the MedicationAdministration resource."
 * ^status = #draft
 * partOf only Reference(FiBaseProcedure or FiBaseMedicationAdministration)
+* medicationReference only Reference(FiBasePatientMedication)
 * subject only Reference(FiBasePatient or Group)
 * context only Reference(FiBaseEncounter or FiBaseEpisodeOfCare)
 * performer.actor only Reference(FiBasePractitioner or FiBasePractitionerRole or FiBasePatient or RelatedPerson or Device)

--- a/input/fsh/medicationStatement.fsh
+++ b/input/fsh/medicationStatement.fsh
@@ -6,7 +6,7 @@ Description: "This is the Finnish base profile for the MedicationStatement resou
 * ^status = #draft
 * basedOn only Reference(FiBaseMedicationRequest or CarePlan or ServiceRequest)
 * partOf only Reference(FiBaseMedicationAdministration or MedicationDispense or FiBaseMedicationStatement or FiBaseProcedure or FiBaseObservation)
-* medicationReference only Reference(FiBaseMedication)
+* medicationReference only Reference(FiBasePatientMedication)
 * subject only Reference(FiBasePatient)
 * context only Reference(FiBaseEncounter or FiBaseEpisodeOfCare)
 * informationSource only Reference(FiBasePatient or FiBasePractitioner or FiBasePractitionerRole or FiBaseOrganization or RelatedPerson)

--- a/input/fsh/patient.fsh
+++ b/input/fsh/patient.fsh
@@ -4,7 +4,6 @@ Id: fi-base-patient
 Title: "FI Base Patient"
 Description: "This is the Finnish base profile for the Patient resource."
 * ^status = #draft
-* id 1..1
 * generalPractitioner only Reference(FiBaseOrganization or FiBasePractitioner or FiBasePractitionerRole)
 * managingOrganization only Reference(FiBaseOrganization)
 * link.other only Reference(FiBasePatient or RelatedPerson)

--- a/input/fsh/patientMedication.fsh
+++ b/input/fsh/patientMedication.fsh
@@ -1,0 +1,8 @@
+Profile: FiBasePatientMedication
+Parent: http://hl7.org/fhir/uv/ipa/StructureDefinition/ipa-medication
+Id: fi-base-patient-medication
+Title: "FI Base Patient Medication"
+Description: "This is the Finnish base profile for the Medication resource for patient access use case."
+* ^status = #draft
+* manufacturer only Reference(FiBaseOrganization)
+* ingredient.itemReference only Reference(Substance or FiBasePatientMedication)

--- a/input/fsh/patientMedicationRequest.fsh
+++ b/input/fsh/patientMedicationRequest.fsh
@@ -1,11 +1,11 @@
-Profile: FiBaseMedicationRequest
-Parent: MedicationRequest
-Id: fi-base-medication-request
-Title: "FI Base MedicationRequest"
-Description: "This is the Finnish base profile for the MedicationRequest resource, for other than patient access use cases."
+Profile: FiBasePatientMedicationRequest
+Parent: http://hl7.org/fhir/uv/ipa/StructureDefinition/ipa-medicationrequest
+Id: fi-base-patient-medication-request
+Title: "FI Base Patient MedicationRequest"
+Description: "This is the Finnish base profile for the MedicationRequest resource for the patient access use case."
 * ^status = #draft
 * reportedReference only Reference(FiBasePatient or FiBasePractitioner or FiBasePractitionerRole)
-* medicationReference only Reference(FiBaseMedication or FiBasePatientMedication)
+* medicationReference only Reference(FiBasePatientMedication)
 * subject only Reference(FiBasePatient)
 * encounter only Reference(FiBaseEncounter)
 * requester only Reference(FiBasePractitioner or FiBasePractitionerRole or FiBasePatient)
@@ -13,6 +13,6 @@ Description: "This is the Finnish base profile for the MedicationRequest resourc
 * recorder only Reference(FiBasePractitioner or FiBasePractitionerRole)
 * reasonReference only Reference(FiBaseCondition or FiBaseObservation)
 * eventHistory only Reference(FiBaseProvenance)
-* priorPrescription only Reference(FiBaseMedicationRequest or FiBasePatientMedicationRequest)
+* priorPrescription only Reference(FiBasePatientMedicationRequest)
 * dispenseRequest.performer only Reference(FiBaseOrganization)
-* basedOn only Reference(CarePlan or FiBaseMedicationRequest or FiBasePatientMedicationRequest or ServiceRequest or ImmunizationRecommendation)	
+* basedOn only Reference(CarePlan or FiBasePatientMedicationRequest or ServiceRequest or ImmunizationRecommendation)	

--- a/input/fsh/practitioner.fsh
+++ b/input/fsh/practitioner.fsh
@@ -4,7 +4,6 @@ Id: fi-base-practitioner
 Title: "FI Base Practitioner"
 Description: "This is the Finnish base profile for the Practitioner resource."
 * ^status = #draft
-* id 1..1
 * qualification.issuer only Reference(FiBaseOrganization)
 
 * identifier ^slicing.discriminator.type = #value

--- a/input/fsh/reasonForCare.fsh
+++ b/input/fsh/reasonForCare.fsh
@@ -85,5 +85,3 @@ Description: "Encoded information on the cause of an adverse effect, when involv
 * value[x] only Coding
 * ^context[+].type = #element
 * ^context[=].expression = "Condition"
-
-

--- a/input/pagecontent/CodeSystem-SecurityLabelCS-intro.md
+++ b/input/pagecontent/CodeSystem-SecurityLabelCS-intro.md
@@ -1,0 +1,9 @@
+The TURVAKIELTO label is the first code to be added into the code system. Many other codes are
+likely to be added, including codes for other
+|data protection preferences in the Suomi.fi infrastructure](https://dvv.fi/en/data-protection) and
+codes for
+[permissions for health data sharing from the Kanta system](https://www.kanta.fi/en/consent-and-denials-of-consent-to-data-sharing).
+Implementer feedback regarding this approach and regarding codes that should be added is
+appreciated!
+{:.stu-note}
+

--- a/input/pagecontent/Patient-patient-with-turvakielto-intro.md
+++ b/input/pagecontent/Patient-patient-with-turvakielto-intro.md
@@ -1,0 +1,10 @@
+The TURVAKIELTO label is the first code to be added into the
+[Finnish CodeSystem for security labels](CodeSystem-SecurityLabelCS.html). Many other codes are
+likely to be added, including codes for other
+|data protection preferences in the Suomi.fi infrastructure](https://dvv.fi/en/data-protection) and
+codes for
+[permissions for health data sharing from the Kanta system](https://www.kanta.fi/en/consent-and-denials-of-consent-to-data-sharing).
+Implementer feedback regarding this approach and regarding codes that should be added is
+appreciated!
+{:.stu-note}
+

--- a/input/pagecontent/StructureDefinition-fi-base-medication-request-intro.md
+++ b/input/pagecontent/StructureDefinition-fi-base-medication-request-intro.md
@@ -1,6 +1,8 @@
 ### Scope and Usage
 
-The FI Base MedicationRequest derives from the MedicationRequest profile of the International
-Patient Access specification.
+This profile is meant for use cases without patient access perspective. For patient access use
+case, please see the
+[FI Base Patient Medication Request](StructureDefinition-fi-base-patient-medication-request.html)
+profile.
 
 {% include fragment-medication.md %}

--- a/input/pagecontent/StructureDefinition-fi-base-patient-intro.md
+++ b/input/pagecontent/StructureDefinition-fi-base-patient-intro.md
@@ -20,22 +20,22 @@ for a person are
 
 The unique identifier is the national person identifier.
 
-##### Patient identifier
+#### Patient identifier
 
 There are two versions of the national person identifier for people living in Finland.
 
-The [official Personal Identifier Code](https://dvv.fi/en/personal-identity-code) (PIC, also known
-as _HETU_) is granted by the Digital And Population Data Services Agency. The `oid` for the
+The [official Personal Identifier Code](https://dvv.fi/en/personal-identity-code) (**PIC**, also
+known as _HETU_) is granted by the Digital And Population Data Services Agency. The `oid` for the
 official PIC is `1.2.246.21`.
 
 When an official PIC is not known or cannot be used for other reasons, a system may generate a
-[Temporary Identifier](https://www.kanta.fi/en/system-developers/test-etiquette#Temporary%20identifier).
+[**temporary identifier**](https://www.kanta.fi/en/system-developers/test-etiquette#Temporary%20identifier).
 There are several ways to create an `oid` for the temporary identifier. The most typical ones are
 described in
 [ISO OID-yksilöintitunnuksen käytön kansalliset periaatteet sosiaali- ja terveysalalla](https://www.hl7.fi/hl7-rajapintakartta/iso-oid-yksilointitunnuksen-kayton-kansalliset-periaatteet-sosiaali-ja-terveysalalla/)
 document (in Finnish).
 
-There are two generally used methods to create a temporary identifier OID.
+There are two generally used methods to create a temporary identifier `oid`.
 
 1. `1.2.246.10.<organization>.22.<year>`, where `<organization>` is the official identifier
 (_y-tunnus_) of the organization and `<year>` the year when the temporary identifier is generated.
@@ -46,7 +46,7 @@ the organization in which the temporary identifier is created.
 The first method is
 [recommended](https://yhteistyotilat.fi/wiki08/display/JULPOKY/7+Potilaan+perustiedot#id-7Potilaanperustiedot-7.1Henkil%C3%B6nyksil%C3%B6intitiedot).
 
-The identifiers are presented to human readers in the 11 character format, without any oid
+The identifiers are presented to human readers in the 11 character format, without any `oid`
 information.
 
 When a PIC is used for a Patient instance, the value of the `identifier.use` field SHOULD be
@@ -61,7 +61,7 @@ In addition to person identifiers for people living in Finland, systems may use 
 that have a special range in the PIC format (the eighth character is `9`). For instance,
 `020516C903K`.
 
-##### Other identifiers
+#### Other identifiers
 
 Other identifiers can also be used to identify the patient. In many cases the national patient
 identifier is not required. In these cases systems SHOULD assign another unique identifier for
@@ -69,22 +69,6 @@ patients. Note that these identifiers MAY be different for different apps, for i
 SHOULD still be the same when the same app asks for the patient information multiple times. 
 
 #### Additional Information
-
-##### Municipality vs address information
-
-Municipality of residence is represented with MunicipalityCode extension. Municipality means in
-this context the municipality which is registered as the primary residence location. The
-municipality of residence is always registered by the
-[Digital and Population Data Services Agency](https://dvv.fi/en/municipality-of-residence). In most
-cases the address information contains the same information presented in MunicipalityCode extension
-but there are situations where `address.city` is not the same as the value in the extension.
-Address is better understood as contact address. More information about the subject can be found on
-[Home municipality](./StructureDefinition-municipality-code.html).
-
-The distiction between these two different location types is important e.g. when patient is being
-transferred from primary care to secondary care via referral. In these cases the secondary care
-unit invoices the primary care service provider but patient may recieve infromation about the given
-care via mail to address which is not located in municipality of recidence.
 
 ##### Name
 
@@ -100,17 +84,36 @@ do not share names or any demographic information by default.
 Both time of birth and time of death SHOULD be recorded with the time component, if known. If the
 time of day is not known, the date SHALL be recorded as a date only, without the time component.
 
-The birth time, when known, SHALL be recorded using the
+The birth time, when recorded, SHALL be recorded using the
 [standard extension](http://hl7.org/fhir/extensions/StructureDefinition-patient-birthTime.html).
 
-#### Non-disclosure for personal safety
+### Municipality vs address information
 
-DVV may grant a [non-disclosure for personal safety](https://dvv.fi/en/non-disclosure-for-personal-safety).
-This is communicated by `TURVAKIELTO` security label.
+Municipality of residence is represented with MunicipalityCode extension. Municipality means in
+this context the municipality which is registered as the primary residence location. The
+municipality of residence is always registered by the
+[Digital and Population Data Services Agency](https://dvv.fi/en/municipality-of-residence). In most
+cases the address information contains the same information presented in MunicipalityCode extension
+but there are situations where `address.city` is not the same as the value in the extension.
+Address is better understood as contact address. More information about the subject can be found on
+[Home municipality](./StructureDefinition-municipality-code.html).
 
-#### Presenting guardian information
+The distiction between these two different location types is important e.g. when patient is being
+transferred from primary care to secondary care via referral. In these cases the secondary care
+unit invoices the primary care service provider but patient may recieve infromation about the given
+care via mail to address which is not located in municipality of recidence.
+
+### Presenting guardian information
 
 In some cases, a guardian could be appointed to the patient if the patients is for ex. incapable of
 managing one's matters due to an illness. In these situations, the guardian's information SHOULD be
 presented with [RelatedPerson](http://hl7.org/fhir/R4/relatedperson.html) resource with the
 relationship type [GUARD](http://hl7.org/fhir/R4/v3/RoleCode/cs.html#:~:text=3-,GUARD,-guardian).
+
+### Non-disclosure for personal safety
+
+The Digital and Population Data Services Agency DVV may grant a
+[non-disclosure for personal safety](https://dvv.fi/en/non-disclosure-for-personal-safety).
+This is communicated by the
+[`TURVAKIELTO`](CodeSystem-SecurityLabelCS.html#SecurityLabelCS-TURVAKIELTO) security label (see
+[an example](Patient-patient-with-turvakielto.html)).

--- a/input/pagecontent/StructureDefinition-fi-base-patient-medication-request-intro.md
+++ b/input/pagecontent/StructureDefinition-fi-base-patient-medication-request-intro.md
@@ -1,0 +1,10 @@
+### Scope and Usage
+
+The FI Base MedicationRequest derives from the MedicationRequest profile of the International
+Patient Access specification.
+
+For use cases with no patient access perspective, please see also the
+[FI Base Medication Request](StructureDefinition-fi-base-medication-request.html) profile.
+
+
+{% include fragment-medication.md %}

--- a/input/pagecontent/ValueSet-SecurityLabelVS-intro.md
+++ b/input/pagecontent/ValueSet-SecurityLabelVS-intro.md
@@ -1,0 +1,9 @@
+The TURVAKIELTO label is the first code to be added into the value set. Many other codes are likely
+to be added, including codes for other
+|data protection preferences in the Suomi.fi infrastructure](https://dvv.fi/en/data-protection) and
+codes for
+[permissions for health data sharing from the Kanta system](https://www.kanta.fi/en/consent-and-denials-of-consent-to-data-sharing).
+Implementer feedback regarding this approach and regarding codes that should be added is
+appreciated!
+{:.stu-note}
+

--- a/input/pagecontent/terminology.md
+++ b/input/pagecontent/terminology.md
@@ -4,8 +4,8 @@ Many of these terminologies are not maintained by HL7 Finland, rather they are p
 maintained elsewhere and included into this implementation guide to raise awareness of their
 existence.
 
-This version of this implementation guide does not define any terminologies. There are other, more
-use case specific implementation guides that may define terminologies for their use cases. See for
+In addition to the terminologies defined in this implementation guide, there are other, more use
+case specific implementation guides that may define terminologies for their use cases. See, for
 instance:
 * Both the [Finnish Appointment IG](https://simplifier.net/finnishappointment) and the
   [Finnish Scheduling IG](https://simplifier.net/finnishschedulingr4/) for scheduling

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -38,7 +38,7 @@ resources:
   Medication/medicationesim1:
     name: Myyntiluvallinen lääkevalmiste
     description: An example Medication instance from Kanta Prescription API
-    exampleCanonical: https://hl7.fi/fhir/finnish-base-profiles/StructureDefinition/fi-base-medication
+    exampleCanonical: https://hl7.fi/fhir/finnish-base-profiles/StructureDefinition/fi-base-patient-medication
   Medication/medicationesim2:
     name: Myyntiluvallinen lääkevalmiste, joka on PKV-lääke
     description: An example Medication instance from Kanta Prescription API
@@ -66,39 +66,39 @@ resources:
   MedicationRequest/medicationrequestesim1:
     name: "1 tabletti 2 kertaa päivässä"
     description: An example MedicationRequest from Kanta Prescription API
-    exampleCanonical: https://hl7.fi/fhir/finnish-base-profiles/StructureDefinition/fi-base-medication-request
+    exampleCanonical: https://hl7.fi/fhir/finnish-base-profiles/StructureDefinition/fi-base-patient-medication-request
   MedicationRequest/medicationrequestesim2:
     name: "2 tablettia aamulla ja 1 tabletti illalla 6 päivän ajan"
     description: An example MedicationRequest from Kanta Prescription API
-    exampleCanonical: https://hl7.fi/fhir/finnish-base-profiles/StructureDefinition/fi-base-medication-request
+    exampleCanonical: https://hl7.fi/fhir/finnish-base-profiles/StructureDefinition/fi-base-patient-medication-request
   MedicationRequest/medicationrequestesim3:
     name: "1-2 tablettia kerran päivässä"
     description: An example MedicationRequest from Kanta Prescription API
-    exampleCanonical: https://hl7.fi/fhir/finnish-base-profiles/StructureDefinition/fi-base-medication-request
+    exampleCanonical: https://hl7.fi/fhir/finnish-base-profiles/StructureDefinition/fi-base-patient-medication-request
   MedicationRequest/medicationrequestesim4:
     name: "1-2 tablettia 1-3 kertaa päivässä"
     description: An example MedicationRequest from Kanta Prescription API
-    exampleCanonical: https://hl7.fi/fhir/finnish-base-profiles/StructureDefinition/fi-base-medication-request
+    exampleCanonical: https://hl7.fi/fhir/finnish-base-profiles/StructureDefinition/fi-base-patient-medication-request
   MedicationRequest/medicationrequestesim5:
     name: "Maanantaisin 1 tabletti ja tarvittaessa keskiviikkoisin 0,5 tablettia 01.06.2020 - 31.12.2020"
     description: An example MedicationRequest from Kanta Prescription API
-    exampleCanonical: https://hl7.fi/fhir/finnish-base-profiles/StructureDefinition/fi-base-medication-request
+    exampleCanonical: https://hl7.fi/fhir/finnish-base-profiles/StructureDefinition/fi-base-patient-medication-request
   MedicationRequest/medicationrequestesim6:
     name: "Lääke tauolla 1.3.2020 - 30.6.2020. Taukoa edeltävä annostus: 25 mg klo 08:00 10 päivän ajan ihon alle"
     description: An example MedicationRequest from Kanta Prescription API
-    exampleCanonical: https://hl7.fi/fhir/finnish-base-profiles/StructureDefinition/fi-base-medication-request
+    exampleCanonical: https://hl7.fi/fhir/finnish-base-profiles/StructureDefinition/fi-base-patient-medication-request
   MedicationRequest/medicationrequestesim7A:
     name: "1 tabletti 2 kertaa päivässä 5 päivän ajan 15.1.2021 alkaen"
     description: An example MedicationRequest from Kanta Prescription API
-    exampleCanonical: https://hl7.fi/fhir/finnish-base-profiles/StructureDefinition/fi-base-medication-request
+    exampleCanonical: https://hl7.fi/fhir/finnish-base-profiles/StructureDefinition/fi-base-patient-medication-request
   MedicationRequest/medicationrequestesim7B:
     name: "1 tabletti 2 kertaa päivässä 5-7 päivän ajan 15.1.2021 alkaen"
     description: An example MedicationRequest from Kanta Prescription API
-    exampleCanonical: https://hl7.fi/fhir/finnish-base-profiles/StructureDefinition/fi-base-medication-request
+    exampleCanonical: https://hl7.fi/fhir/finnish-base-profiles/StructureDefinition/fi-base-patient-medication-request
   MedicationRequest/medicationrequestesim8:
     name: "Tarvittaessa 2 tablettia 3 kertaa viikossa 16.2.2021 alkaen"
     description: An example MedicationRequest from Kanta Prescription API
-    exampleCanonical: https://hl7.fi/fhir/finnish-base-profiles/StructureDefinition/fi-base-medication-request
+    exampleCanonical: https://hl7.fi/fhir/finnish-base-profiles/StructureDefinition/fi-base-patient-medication-request
   MedicationRequest/medicationrequestesim9:
     name: "Tarvittaessa 1-2 tippaa 3-4 tunnin välein"
     description: An example MedicationRequest from Kanta Prescription API


### PR DESCRIPTION
Add *generic* profiles for `Medication` and `MedicationRequest` for Kela's use case where they cannot use the IPA dependent profiles (because `Medication.code` is mandatory there, and in Kela's use case they may not have it available).