### PR TITLE
Update publisher script

### DIFF
--- a/_updatePublisher.sh
+++ b/_updatePublisher.sh
@@ -117,13 +117,16 @@ if [[ $skipPrompts == true ]] || [[ $response =~ ^[yY].*$ ]]; then
 
   curl -L $gencont_sh_url -o /tmp/_gencontinuous.new
   cp /tmp/_gencontinuous.new _gencontinuous.sh
+  chmod +x _gencontinuous.sh
   rm /tmp/_gencontinuous.new
 
   curl -L $gen_sh_url -o /tmp/_genonce.new
   cp /tmp/_genonce.new _genonce.sh
+  chmod +x _genonce.sh
   rm  /tmp/_genonce.new
 
   curl -L $update_sh_url -o /tmp/_updatePublisher.new
   cp /tmp/_updatePublisher.new _updatePublisher.sh
+  chmod +x _updatePublisher.sh
   rm /tmp/_updatePublisher.new
 fi


### PR DESCRIPTION
Apply newest version of _updatePublisher.sh that _updatePublisher.sh would update by itself. We control this script in git and must update it manually.

Should fix build errors on linux (including dockerized build).