### PR TITLE
Work around sushi problems

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM node:lts-bullseye
-RUN npm install -g fsh-sushi
+RUN npm install -g fsh-sushi@2.10.2
 
 RUN apt-get update && apt-get -y install openjdk-17-jdk-headless ruby-full build-essential zlib1g-dev
-RUN gem install jekyll bundler
+RUN gem install jekyll bundler 

--- a/README.md
+++ b/README.md
@@ -65,14 +65,14 @@ With the above requirements installed locally, run
 #### On OSX, Linux, or Unix
 
 ``` bash
-npm install -g fsh-sushi
+npm install -g fsh-sushi@2.10.2
 ./_updatePublisher.sh --yes
 ./_genonce.sh
 ```
 
 #### On Windows
 ```
-npm install -g fsh-sushi
+npm install -g fsh-sushi@2.10.2
 .\_updatePublisher.bat --yes
 .\_genonce.bat
 ```

--- a/fsh.ini
+++ b/fsh.ini
@@ -1,0 +1,2 @@
+[FSH]
+timeout=600


### PR DESCRIPTION
Use specific older version of sushi in order to work around performance and timeout problems in 3.3.0.

Adjusts sushi timeout in ig-specific config.