### PR TITLE
Use versions in codings

### DIFF
--- a/input/fsh/examples/appointmentGeneralPractitioner.fsh
+++ b/input/fsh/examples/appointmentGeneralPractitioner.fsh
@@ -4,7 +4,7 @@ Usage: #example
 Title: "GP appointment"
 Description: "Example of an appointment with general practitioner."
 * id = "appointment-general-practitioner"
-* appointmentType = urn:oid:1.2.246.537.6.884.2015#101
+* appointmentType = urn:oid:1.2.246.537.6.884|2015#101
 * created = "2023-01-20T08:45:15+02:00"
 * description = "Kuume"
 * end = "2023-01-20T10:20:00+02:00"
@@ -27,8 +27,8 @@ Description: "Example of an appointment with general practitioner."
 * participant[=].status = #accepted
 * participant[+].actor = Reference(AT-340)
 * participant[=].status = #accepted
-* serviceCategory = urn:oid:1.2.246.537.6.50.201801#SOTE9.2
-* serviceType = urn:oid:1.2.246.537.6.49.201501#EEA
+* serviceCategory = urn:oid:1.2.246.537.6.50|201801#SOTE9.2
+* serviceType = urn:oid:1.2.246.537.6.49|201501#EEA
 * start = "2023-01-20T10:00:00+02:00"
 * status = #fulfilled
 * slot = Reference(FreeSlot)

--- a/input/fsh/examples/diagnosisAdverseEffect.fsh
+++ b/input/fsh/examples/diagnosisAdverseEffect.fsh
@@ -4,32 +4,20 @@ Title: "Condition - an example diagnosis with an adverse effect."
 Description: "An example of a diagnosis using the FiBaseReasonForCare profile. This diagnosis demonstrates a case that has an adverse effect."
 Usage: #example
 * id = "id-for-diagnosis-3"
-* category[0].coding.system = #http://terminology.hl7.org/CodeSystem/condition-category
-* category[0].coding.code = #encounter-diagnosis
+* category.coding = http://terminology.hl7.org/CodeSystem/condition-category#encounter-diagnosis
 
 * subject = Reference(PatientOfMunicipality)
-* code.coding.system = #urn:oid:1.2.246.537.6.1.1999
-* code.coding.code = #T81.9
-* code.coding.display = "Määrittämätön toimenpidekomplikaatio"
+* code.coding = urn:oid:1.2.246.537.6.1|1999#T81.9 "Määrittämätön toimenpidekomplikaatio"
 * code.text = "Määrittämätön toimenpidekomplikaatio"
 
 * onsetDateTime = "2023-01-05T02:06:24+03:00"
 
-* clinicalStatus.coding.code = #active
-* clinicalStatus.coding.system = #http://terminology.hl7.org/CodeSystem/condition-clinical
+* clinicalStatus.coding = http://terminology.hl7.org/CodeSystem/condition-clinical#active
 
-* extension[PrimaryCondition].valueCoding.system = #urn:oid:1.2.246.537.5.40005.2003
-* extension[PrimaryCondition].valueCoding.code = #SIVU
-* extension[PrimaryCondition].valueCoding.display = "Sivudiagnoosi tai toissijainen toimenpide"
+* extension[PrimaryCondition].valueCoding = urn:oid:1.2.246.537.5.40005|2003#SIVU "Sivudiagnoosi tai toissijainen toimenpide"
 
-* extension[Permanence].valueCoding.system = #urn:oid:1.2.246.537.5.40003.2003
-* extension[Permanence].valueCoding.code = #KER
-* extension[Permanence].valueCoding.display = "Kertaluonteinen"
+* extension[Permanence].valueCoding = urn:oid:1.2.246.537.5.40003|2003#KER "Kertaluonteinen"
 
-* extension[ConditionExternalCause].valueCoding.system = #urn:oid:1.2.246.537.6.1.1999
-* extension[ConditionExternalCause].valueCoding.code = #Y60.0
-* extension[ConditionExternalCause].valueCoding.display = "Leikkauksen yhteydessä vahingossa syntynyt haava, punktio, perforaatio tai verenvuoto"
+* extension[ConditionExternalCause].valueCoding = urn:oid:1.2.246.537.6.1|1999#Y60.0 "Leikkauksen yhteydessä vahingossa syntynyt haava, punktio, perforaatio tai verenvuoto"
 
-* extension[CauseOfAdverseEffect].valueCoding.system = #urn:oid:1.2.246.537.6.2.2007
-* extension[CauseOfAdverseEffect].valueCoding.code = #JAB10
-* extension[CauseOfAdverseEffect].valueCoding.display = "Nivustyrän korjaus"
+* extension[CauseOfAdverseEffect].valueCoding = urn:oid:1.2.246.537.6.2|2007#JAB10 "Nivustyrän korjaus"

--- a/input/fsh/examples/diagnosisMedicationAccident.fsh
+++ b/input/fsh/examples/diagnosisMedicationAccident.fsh
@@ -4,36 +4,22 @@ Title: "Condition - an example diagnosis with external cause, accident and medic
 Description: "An example of a diagnosis using the FiBaseReasonForCare profile. This diagnosis demonstrates a case that has external cause, accident and medication information."
 Usage: #example
 * id = "id-for-diagnosis-2"
-* category[0].coding.system = #http://terminology.hl7.org/CodeSystem/condition-category
-* category[0].coding.code = #encounter-diagnosis
+* category.coding = http://terminology.hl7.org/CodeSystem/condition-category#encounter-diagnosis
 
 * subject = Reference(PatientOfMunicipality)
-* code.coding.system = #urn:oid:1.2.246.537.6.1.1999
-* code.coding.code = #T88.7
-* code.coding.display = "Määrittämätön lääkeaineen epäedullinen vaikutus"
+* code.coding = urn:oid:1.2.246.537.6.1|1999#T88.7 "Määrittämätön lääkeaineen epäedullinen vaikutus"
 * code.text = "Määrittämätön lääkeaineen epäedullinen vaikutus"
 
 * onsetDateTime = "2023-01-05T02:06:24+03:00"
 
-* clinicalStatus.coding.code = #active
-* clinicalStatus.coding.system = #http://terminology.hl7.org/CodeSystem/condition-clinical
+* clinicalStatus.coding = http://terminology.hl7.org/CodeSystem/condition-clinical#active
 
-* extension[PrimaryCondition].valueCoding.system = #urn:oid:1.2.246.537.5.40005.2003
-* extension[PrimaryCondition].valueCoding.code = #PAA
-* extension[PrimaryCondition].valueCoding.display = "Päädiagnoosi tai päätoimenpide"
+* extension[PrimaryCondition].valueCoding = urn:oid:1.2.246.537.5.40005|2003#PAA "Päädiagnoosi tai päätoimenpide"
 
-* extension[Permanence].valueCoding.system = #urn:oid:1.2.246.537.5.40003.2003
-* extension[Permanence].valueCoding.code = #KER
-* extension[Permanence].valueCoding.display = "Kertaluonteinen"
+* extension[Permanence].valueCoding = urn:oid:1.2.246.537.5.40003|2003#KER "Kertaluonteinen"
 
-* extension[ConditionExternalCause].valueCoding.system = #urn:oid:1.2.246.537.6.1.1999
-* extension[ConditionExternalCause].valueCoding.code = #X44
-* extension[ConditionExternalCause].valueCoding.display = "Lääkkeiden tai lääkkeenomaisten aineiden aiheuttama myrkytystapaturma tai muu altistuminen"
+* extension[ConditionExternalCause].valueCoding = urn:oid:1.2.246.537.6.1|1999#X44 "Lääkkeiden tai lääkkeenomaisten aineiden aiheuttama myrkytystapaturma tai muu altistuminen"
 
-* extension[ConditionCategorizationOfAccident].valueCoding.system = #urn:oid:1.2.246.537.6.1.1999
-* extension[ConditionCategorizationOfAccident].valueCoding.code = #Y95.0
-* extension[ConditionCategorizationOfAccident].valueCoding.display = "Tapaturma sairaalassa tai sairaalaoloihin liittyvä ulkoinen tekijä"
+* extension[ConditionCategorizationOfAccident].valueCoding = urn:oid:1.2.246.537.6.1|1999#Y95.0 "Tapaturma sairaalassa tai sairaalaoloihin liittyvä ulkoinen tekijä"
 
-* extension[ConditionCausedByMedication].valueCoding.system = #urn:oid:1.2.246.537.6.32.2007
-* extension[ConditionCausedByMedication].valueCoding.code = #M01AE01
-* extension[ConditionCausedByMedication].valueCoding.display = "BURANA 200 mg tabletti, kalvopäällysteinen"
+* extension[ConditionCausedByMedication].valueCoding = urn:oid:1.2.246.537.6.32|2007#M01AE01 "BURANA 200 mg tabletti, kalvopäällysteinen"

--- a/input/fsh/examples/diagnosisSimple.fsh
+++ b/input/fsh/examples/diagnosisSimple.fsh
@@ -4,28 +4,17 @@ Title: "Condition - an example diagnosis"
 Description: "An example of a diagnosis using the FiBaseReasonForCare profile. This diagnosis is asserted by a clinician."
 Usage: #example
 * id = "id-for-diagnosis-1"
-* category[0].coding.system = #http://terminology.hl7.org/CodeSystem/condition-category
-* category[0].coding.code = #encounter-diagnosis
+* category.coding = http://terminology.hl7.org/CodeSystem/condition-category#encounter-diagnosis
 
 * subject = Reference(PatientOfMunicipality)
-* code.coding.system = #urn:oid:1.2.246.537.6.1.1999
-* code.coding.code = #H36.03
-* code.coding.display = "Proliferatiivinen diabeettinen retinopatia"
+* code.coding = urn:oid:1.2.246.537.6.1|1999#H36.03 "Proliferatiivinen diabeettinen retinopatia"
 * code.text = "Proliferatiivinen diabeettinen retinopatia, vasen, laserhoidettu"
 
-* evidence[0].code.coding.system = #urn:oid:1.2.246.537.6.1.1999
-* evidence[0].code.coding.code = #E11.3
-* evidence[0].code.coding.display = "Aikuistyypin diabetes diabeteksen silmäkomplikaatiot"
-
+* evidence.code.coding = urn:oid:1.2.246.537.6.1|1999#E11.3 "Aikuistyypin diabetes diabeteksen silmäkomplikaatiot"
 * onsetDateTime = "2023-01-05T02:06:24+03:00"
 
-* clinicalStatus.coding.code = #active
-* clinicalStatus.coding.system = #http://terminology.hl7.org/CodeSystem/condition-clinical
+* clinicalStatus.coding = http://terminology.hl7.org/CodeSystem/condition-clinical#active
 
-* extension[PrimaryCondition].valueCoding.system = #urn:oid:1.2.246.537.5.40005.2003
-* extension[PrimaryCondition].valueCoding.code = #PAA
-* extension[PrimaryCondition].valueCoding.display = "Päädiagnoosi tai päätoimenpide"
+* extension[PrimaryCondition].valueCoding = urn:oid:1.2.246.537.5.40005|2003#PAA "Päädiagnoosi tai päätoimenpide"
 
-* extension[Permanence].valueCoding.system = #urn:oid:1.2.246.537.5.40003.2003
-* extension[Permanence].valueCoding.code = #PYS
-* extension[Permanence].valueCoding.display = "Pysyväisluonteinen"
+* extension[Permanence].valueCoding = urn:oid:1.2.246.537.5.40003|2003#PYS "Pysyväisluonteinen"

--- a/input/fsh/examples/encounterAmbulatory.fsh
+++ b/input/fsh/examples/encounterAmbulatory.fsh
@@ -7,9 +7,7 @@ Usage: #example
 * identifier.use = #usual
 * identifier.value = "id-for-visit"
 * status = #finished
-* class.system = #http://terminology.hl7.org/CodeSystem/v3-ActCode
-* class.code = #AMB
-* class.display = "ambulatory"
+* class = http://terminology.hl7.org/CodeSystem/v3-ActCode#AMB "ambulatory"
 * subject.reference = "Patient/patient-of-municipality"
 * period.start = "2022-02-28T15:03:00+02:00"
 * period.end = "2022-02-28T15:33:00+02:00"

--- a/input/fsh/examples/encounterAtWardInProgress.fsh
+++ b/input/fsh/examples/encounterAtWardInProgress.fsh
@@ -7,9 +7,7 @@ Usage: #example
 * identifier.use = #usual
 * identifier.value = "id-for-ward-encounter"
 * status = #in-progress
-* class.system = #http://terminology.hl7.org/CodeSystem/v3-ActCode
-* class.code = #IMP
-* class.display = "inpatient encounter"
+* class = http://terminology.hl7.org/CodeSystem/v3-ActCode#IMP "inpatient encounter"
 * subject.reference = "Patient/patient-of-municipality"
 * period.start = "2022-02-27T01:03:00+02:00"
 * serviceProvider.reference = "Organization/1.2.246.10.8286189.10.100012"

--- a/input/fsh/examples/encounterPalvelutapahtuma.fsh
+++ b/input/fsh/examples/encounterPalvelutapahtuma.fsh
@@ -7,9 +7,7 @@ Usage: #example
 * identifier.use = #official
 * identifier.value = "urn:oid:1.2.246.10.6794809.14011.2023.200035"
 * status = #in-progress
-* class.system = #http://terminology.hl7.org/CodeSystem/v3-ActCode
-* class.code = #IMP
-* class.display = "inpatient encounter"
+* class = http://terminology.hl7.org/CodeSystem/v3-ActCode#IMP "inpatient encounter"
 * subject.reference = "Patient/patient-of-municipality"
 * period.start = "2022-02-27T01:03:00+02:00"
 * serviceProvider.reference = "Organization/1.2.246.10.8286189.10.100012"
@@ -21,9 +19,7 @@ Description: "An example of a FI Base encounter which is part of another encount
 Usage: #example
 * id = "id-for-child-encounter"
 * status = #in-progress
-* class.system = #http://terminology.hl7.org/CodeSystem/v3-ActCode
-* class.code = #IMP
-* class.display = "inpatient encounter"
+* class = http://terminology.hl7.org/CodeSystem/v3-ActCode#IMP "inpatient encounter"
 * partOf = Reference(EncounterPalvelutapahtuma) 
 * subject.reference = "Patient/patient-of-municipality"
 * period.start = "2022-02-27T01:03:00+02:00"
@@ -40,13 +36,10 @@ Description: "An example of a FI Base encounter which is part of another encount
 Usage: #example
 * id = "id-for-child-encounter-2"
 * status = #finished
-* class.system = #http://terminology.hl7.org/CodeSystem/v3-ActCode
-* class.code = #OBSENC
-* class.display = "observation encounter"
+* class = http://terminology.hl7.org/CodeSystem/v3-ActCode#OBSENC "observation encounter"
 * partOf = Reference(EncounterPalvelutapahtuma) 
 * subject.reference = "Patient/patient-of-municipality"
 * period.start = "2022-02-28T12:03:00+02:00"
 * period.end = "2022-02-28T12:18:00+02:00"
 * serviceProvider.type = #ServiceProvider
 * serviceProvider.identifier.value = "1.2.246.10.8286189.10.100014"
-

--- a/input/fsh/examples/healthcareServiceExample.fsh
+++ b/input/fsh/examples/healthcareServiceExample.fsh
@@ -6,11 +6,11 @@ Usage: #example
 * id = "healthcareService-example"
 * active = true
 * appointmentRequired = true
-* category[0] = urn:oid:1.2.246.537.6.50.201801#SOTE9.2
-* category[+] = urn:oid:1.2.246.537.6.121.201801#E
+* category[0] = urn:oid:1.2.246.537.6.50|201801#SOTE9.2
+* category[+] = urn:oid:1.2.246.537.6.121|201801#E
 * comment = "Normaali vo-aika sh:lle ja lääkäreille"
 * name = "Vastaanottoaika*"
-* type[0] = urn:oid:1.2.246.537.6.49.201501#EEA
-* type[+] = urn:oid:1.2.246.537.6.49.201501#ADA001
-* type[+] = urn:oid:1.2.246.537.6.125.2008#T11
-* type[+] = urn:oid:1.2.246.537.6.124.2008#SH
+* type[0] = urn:oid:1.2.246.537.6.49|201501#EEA
+* type[+] = urn:oid:1.2.246.537.6.49|201501#ADA001
+* type[+] = urn:oid:1.2.246.537.6.125|2008#T11
+* type[+] = urn:oid:1.2.246.537.6.124|2008#SH

--- a/input/fsh/examples/immunizationVaccinationExample.fsh
+++ b/input/fsh/examples/immunizationVaccinationExample.fsh
@@ -6,7 +6,7 @@ Usage: #example
 * identifier.system = "urn:ietf:rfc:3986"
 * identifier.value = "urn:oid:1.3.6.1.4.1.21367.2005.3.7.1234"
 * status = #completed
-* vaccineCode = urn:oid:1.2.246.537.6.32.2007#J07BA01
+* vaccineCode = urn:oid:1.2.246.537.6.32|2007#J07BA01
 * vaccineCode.text = "Inaktivoitu puutiaisaivotulehdusrokote (koko virus)"
 * patient = Reference(PatientOfMunicipality)
 * encounter = Reference(EncounterPalvelutapahtuma)
@@ -14,19 +14,13 @@ Usage: #example
 * primarySource = false
 * location = Reference(LocationExample)
 * expirationDate = "2025-02-15"
-* site.coding[Vaccination-site]
-  * system = #urn:oid:1.2.246.537.6.110.2007
-  * code = #OO
-* route.coding[Vaccination-route]
-  * system = #urn:oid:1.2.246.537.6.111.2007
-  * code = #IM
+* site.coding[Vaccination-site] = urn:oid:1.2.246.537.6.110|2007#OO
+* route.coding[Vaccination-route] = urn:oid:1.2.246.537.6.111|2007#IM
 * doseQuantity = 5 'mg'
-* protocolApplied.targetDisease.coding
-  * system = #urn:oid:1.2.246.537.6.609.201501
-  * code = #TBE
+* protocolApplied.targetDisease.coding = urn:oid:1.2.246.537.6.609|20150#TBE
 * protocolApplied.doseNumberPositiveInt = 1
 * protocolApplied.seriesDosesPositiveInt = 3
-* performer[+].function = http://terminology.hl7.org/CodeSystem/v2-0443#AP
+* performer[0].function = http://terminology.hl7.org/CodeSystem/v2-0443#AP
 * performer[=].actor = Reference(PractitionerLicensedPhysician)
 * reasonCode = http://snomed.info/sct#429060002
 * extension[vaccinationRecorder].valueReference = Reference(PractitionerLicensedPhysician)

--- a/input/fsh/examples/locationBedExample.fsh
+++ b/input/fsh/examples/locationBedExample.fsh
@@ -7,5 +7,4 @@ Usage: #example
 * mode = #instance
 * name = "Vuode 3"
 * status = #active
-* physicalType.coding.system = #http://terminology.hl7.org/CodeSystem/location-physical-type
-* physicalType.coding.code = #bd
+* physicalType.coding = http://terminology.hl7.org/CodeSystem/location-physical-type#bd

--- a/input/fsh/examples/patientOfMunicipality.fsh
+++ b/input/fsh/examples/patientOfMunicipality.fsh
@@ -6,8 +6,7 @@ Usage: #example
 * id = "patient-of-municipality"
 * identifier[PIC]
   * use = #official
-  * type.coding.system = "http://terminology.hl7.org/CodeSystem/v2-0203"
-  * type.coding.code = #NNFIN
+  * type.coding = http://terminology.hl7.org/CodeSystem/v2-0203#NNFIN
   * system = #urn:oid:1.2.246.21
   * value = "010190-999Y"
 * gender = #male
@@ -20,9 +19,6 @@ Usage: #example
 * address.use = #home
 * address.line[0] = "Testikatu 1"
 * address.line[+] = "37910 Akaa"
-* communication.language.coding.system = #urn:oid:2.16.840.1.113883.4.642.3.20
-* communication.language.coding.code = #fi
+* communication.language.coding = urn:oid:2.16.840.1.113883.4.642.3.20#fi
 * active = true
-* extension[MunicipalityCode].valueCoding.system = #urn:oid:1.2.246.537.6.21.2003
-* extension[MunicipalityCode].valueCoding.code = #020
-* extension[MunicipalityCode].valueCoding.display = "Akaa"
+* extension[MunicipalityCode].valueCoding = urn:oid:1.2.246.537.6.21|2003#020 "Akaa"

--- a/input/fsh/examples/patientWithTurvakielto.fsh
+++ b/input/fsh/examples/patientWithTurvakielto.fsh
@@ -7,8 +7,7 @@ Usage: #example
 * id = "patient-with-turvakielto"
 * identifier[PIC]
   * use = #official
-  * type.coding.system = "http://terminology.hl7.org/CodeSystem/v2-0203"
-  * type.coding.code = #NNFIN
+  * type.coding = http://terminology.hl7.org/CodeSystem/v2-0203#NNFIN
   * system = #urn:oid:1.2.246.21
   * value = "010190-999X"
 * birthDate = "1990-01-01"
@@ -16,6 +15,4 @@ Usage: #example
   * given = "Turva"
   * family = "Henkilö"
 * active = true
-* extension[MunicipalityCode].valueCoding.system = #urn:oid:1.2.246.537.6.21.2003
-* extension[MunicipalityCode].valueCoding.code = #020
-* extension[MunicipalityCode].valueCoding.display = "Akaa"
+* extension[MunicipalityCode].valueCoding = urn:oid:1.2.246.537.6.21|2003#020 "Akaa"

--- a/input/fsh/examples/practitionerLicensedPhysician.fsh
+++ b/input/fsh/examples/practitionerLicensedPhysician.fsh
@@ -28,9 +28,9 @@ Usage: #example
 * name.family = "Doctor"
 * name.given = "Dave"
 * name.suffix = "dr."
-* qualification[0].code = urn:oid:1.2.246.537.6.140.2008#001
-* qualification[+].code = urn:oid:1.2.246.537.6.148.2008#86152-322
-* qualification[+].code = urn:oid:1.2.246.537.6.74.2001#2131
+* qualification[0].code = urn:oid:1.2.246.537.6.140|2008#001
+* qualification[+].code = urn:oid:1.2.246.537.6.148|2008#86152-322
+* qualification[+].code = urn:oid:1.2.246.537.6.74|2001#2131
 * qualification[+].code = urn:oid:2.16.840.1.113883.18.220#MD
 * telecom.system = #email
 * telecom.use = #work

--- a/input/fsh/examples/procedureColonomy.fsh
+++ b/input/fsh/examples/procedureColonomy.fsh
@@ -5,13 +5,9 @@ Description: "This example describes main procedure, colotomy, with reference to
 Usage: #example
 * identifier.value = "3456"
 * status = #completed
-* category.coding[0]
-  * .system = #urn:oid:1.2.246.537.6.601
-  * .code = #TOI
-* code.coding[0].system = #urn:oid:1.2.246.537.6.2
-* code.coding[0].code = #JFA16
-* code.coding[1].system = "http://snomed.info/sct"
-* code.coding[1].code = #9215005
+* category.coding[0] = urn:oid:1.2.246.537.6.601#TOI
+* code.coding[0] = urn:oid:1.2.246.537.6.2#JFA16
+* code.coding[+] = http://snomed.info/sct#9215005
 * code.text = "Colotomy"
 * performedDateTime = "2022-06-08T09:00:00.000Z"
 * subject = Reference(PatientOfMunicipality)

--- a/input/fsh/examples/procedurePartOfMainProcedure.fsh
+++ b/input/fsh/examples/procedurePartOfMainProcedure.fsh
@@ -6,11 +6,8 @@ Usage: #example
 * identifier.value = "12345"
 * partOf = Reference(ProcedureColotomy)
 * status = #completed
-* category.coding[0]
-  * system = #urn:oid:1.2.246.537.6.601
-  * code = #PIENTOI
-* code.coding[0].system = "http://snomed.info/sct"
-* code.coding[0].code = #76164006
+* category.coding = urn:oid:1.2.246.537.6.601#PIENTOI
+* code.coding = http://snomed.info/sct#76164006
 * code.text = "Biopsy of colon"
 * subject = Reference(PatientOfMunicipality)
 * performer.actor = Reference(PractitionerLicensedPhysician)

--- a/input/fsh/examples/provenanceCustodianIndividual.fsh
+++ b/input/fsh/examples/provenanceCustodianIndividual.fsh
@@ -8,13 +8,10 @@ Usage: #example
 * recorded = "2015-02-07T13:28:17.239+02:00"
 * agent[custodian]
   * type
-    * coding[0] = http://terminology.hl7.org/CodeSystem/v3-ParticipationType#CST "custodian"
+    * coding = http://terminology.hl7.org/CodeSystem/v3-ParticipationType#CST "custodian"
     * text = "Rekisterinpitäjä"
-  * role[0]
-    * coding[0]
-      * system = "urn:oid:1.2.246.537.5.40172"
-      * code = #2
-      * display = "Yksityinen"
+  * role
+    * coding = urn:oid:1.2.246.537.5.40172#2 "Yksityinen"
     * text = "Yksityinen"
   * who
     * type = #Practitioner

--- a/input/fsh/examples/provenanceCustodianOccupationalHealthcare.fsh
+++ b/input/fsh/examples/provenanceCustodianOccupationalHealthcare.fsh
@@ -11,10 +11,7 @@ Usage: #example
     * coding[0] = http://terminology.hl7.org/CodeSystem/v3-ParticipationType#CST "custodian"
     * text = "Rekisterinpitäjä"
   * role[0]
-    * coding[0]
-      * system = "urn:oid:1.2.246.537.5.40172"
-      * code = #2
-      * display = "Yksityinen"
+    * coding[0] = urn:oid:1.2.246.537.5.40172#2 "Yksityinen"
     * text = "Yksityinen"
   * who
     * type = #Organization

--- a/input/fsh/examples/provenanceCustodianPublicHealthcare.fsh
+++ b/input/fsh/examples/provenanceCustodianPublicHealthcare.fsh
@@ -8,13 +8,10 @@ Usage: #example
 * recorded = "2023-08-25T16:42:17.239+03:00"
 * agent[custodian]
   * type
-    * coding[0] = http://terminology.hl7.org/CodeSystem/v3-ParticipationType#CST "custodian"
+    * coding = http://terminology.hl7.org/CodeSystem/v3-ParticipationType#CST "custodian"
     * text = "Rekisterinpitäjä"
-  * role[0]
-    * coding[0]
-      * system = "urn:oid:1.2.246.537.5.40172"
-      * code = #1
-      * display = "Julkinen"
+  * role
+    * coding = urn:oid:1.2.246.537.5.40172#1 "Julkinen"
     * text = "Julkinen"
   * who
     * type = #Organization

--- a/input/fsh/examples/slotExampleFreeSlot.fsh
+++ b/input/fsh/examples/slotExampleFreeSlot.fsh
@@ -4,9 +4,9 @@ Title: "Free slot (kertakäynti yleislääkärillä)"
 Description: "Example of a free slot with reference to Schedule and information about service category, service type and appointment type presented in THL code system format."
 Usage: #example
 * identifier.value = "123456789"
-* serviceCategory = urn:oid:1.2.246.537.6.50.201801#SOTE3 "Lääkäripalvelut"
-* serviceType = urn:oid:1.2.246.537.6.49.201501#EE "Yleislääkärin palvelu"
-* appointmentType = urn:oid:1.2.246.537.6.884.2015#10 "Kertakäynti toimipaikassa"
+* serviceCategory = urn:oid:1.2.246.537.6.50|201801#SOTE3 "Lääkäripalvelut"
+* serviceType = urn:oid:1.2.246.537.6.49|201501#EE "Yleislääkärin palvelu"
+* appointmentType = urn:oid:1.2.246.537.6.884|2015#10 "Kertakäynti toimipaikassa"
 * schedule = Reference(ScheduleExample)
 * status = #free
 * start = "2023-01-01T12:00:00+02:00"

--- a/input/fsh/immunization.fsh
+++ b/input/fsh/immunization.fsh
@@ -20,10 +20,10 @@ Description: "This is a base profile for Finnish Immunization resource."
   * ^short = "Defining administered product or substance by using ATC or VNR code."
 
 * vaccineCode.coding contains ATC 0..1
-* vaccineCode.coding[ATC].system = #urn:oid:1.2.246.537.6.32.2007 (exactly)
+* vaccineCode.coding[ATC].system = #urn:oid:1.2.246.537.6.32
 
 * vaccineCode.coding contains VNR 0..1
-* vaccineCode.coding[VNR].system = #urn:oid:1.2.246.537.6.55 (exactly)
+* vaccineCode.coding[VNR].system = #urn:oid:1.2.246.537.6.55
 
 * vaccineCode.text
   * ^short = "Insert product name."
@@ -35,7 +35,7 @@ Description: "This is a base profile for Finnish Immunization resource."
 * site.coding ^slicing.ordered = false
 
 * site.coding contains Vaccination-site 0..1
-* site.coding[Vaccination-site].system = #urn:oid:1.2.246.537.6.110.2007 (exactly)
+* site.coding[Vaccination-site].system = #urn:oid:1.2.246.537.6.110
 
 * route.coding ^slicing.discriminator.type = #value
 * route.coding ^slicing.discriminator.path = "system"
@@ -44,7 +44,7 @@ Description: "This is a base profile for Finnish Immunization resource."
 * route.coding ^slicing.ordered = false
 
 * route.coding contains Vaccination-route 0..1
-* route.coding[Vaccination-route].system = #urn:oid:1.2.246.537.6.111.2007 (exactly)
+* route.coding[Vaccination-route].system = #urn:oid:1.2.246.537.6.111
 
 * protocolApplied.targetDisease.coding ^slicing.discriminator.type = #value
 * protocolApplied.targetDisease.coding ^slicing.discriminator.path = "system"
@@ -54,7 +54,7 @@ Description: "This is a base profile for Finnish Immunization resource."
   * ^short = "Vaccine preventatable disease being targetted defined by using THL code system"
 
 * protocolApplied.targetDisease.coding contains THL-code 0..1
-* protocolApplied.targetDisease.coding[THL-code].system = #urn:oid:1.2.246.537.6.609.201501 (exactly)
+* protocolApplied.targetDisease.coding[THL-code].system = #urn:oid:1.2.246.537.6.609
 
 * reaction.detail ^short = "Reference to contained Observation resource. The contained Observation has relevant diagnose codes."
 

--- a/input/fsh/patient.fsh
+++ b/input/fsh/patient.fsh
@@ -45,7 +45,7 @@ Description: "Extension for home municipality. Home municipality is relevant for
 * ^context.expression = "Patient"
 * value[x] only Coding
 * valueCoding 1..1
-  * system = #urn:oid:1.2.246.537.6.21.2003
+  * system = #urn:oid:1.2.246.537.6.21
 
 Extension: PatientProfession
 Id: patient-profession

--- a/input/fsh/reasonForCare.fsh
+++ b/input/fsh/reasonForCare.fsh
@@ -21,7 +21,7 @@ Title: "Primary condition for encounter"
 Description: "Encoded information of whether this is the primary/main condition for encounter."
 * value[x] only Coding
 * valueCoding 1..1
-  * system = #urn:oid:1.2.246.537.5.40005.2003
+  * system = #urn:oid:1.2.246.537.5.40005
 * ^context[+].type = #element
 * ^context[=].expression = "Condition"
 
@@ -31,7 +31,7 @@ Title: "Permanence of condition"
 Description: "Encoded information of whether this is the permanent."
 * value[x] only Coding
 * valueCoding 1..1
-  * system = #urn:oid:1.2.246.537.5.40003.2003
+  * system = #urn:oid:1.2.246.537.5.40003
 * ^context[+].type = #element
 * ^context[=].expression = "Condition"
 

--- a/input/ignoreWarnings.txt
+++ b/input/ignoreWarnings.txt
@@ -10,8 +10,6 @@ Code System URI 'http://terminology.own.com' is unknown so the code cannot be va
 Code System URI 'http://ownSystem.com/phr-cs-fitnesscategory' is unknown so the code cannot be validated
 Code System URI 'http://example.oma' is unknown so the code cannot be validated
 Profile reference 'http://example.org/StructureDefinition/other-bloodglucose-structuredefinition' has not been checked because it is unknown, and the validator is set to not fetch unknown profiles
-Profile reference 'http://example.oma/sd/careplan' has not been checked because it is unknown, and the validator is set to not fetch unknown profiles
-Profile reference 'http://example.org/StructureDefinition/other-bloodglucose-structuredefinition' has not been checked because it is unknown, and the validator is set to not fetch unknown profiles
 
 
 # Kanta profiles are not included in this guide. It's OK not to validate the Kanta PHR examples imported from the Kanta IGs against them.
@@ -27,7 +25,6 @@ Profile reference 'http://phr.kanta.fi/StructureDefinition/fiphr-sd-macronutrien
 Profile reference 'http://phr.kanta.fi/StructureDefinition/fiphr-sd-metbystandardrmr' has not been checked because it is unknown, and the validator is set to not fetch unknown profiles
 Profile reference 'http://phr.kanta.fi/StructureDefinition/fiphr-sd-moderatetovigorouspatime' has not been checked because it is unknown, and the validator is set to not fetch unknown profiles
 Profile reference 'http://phr.kanta.fi/StructureDefinition/fiphr-sd-patient' has not been checked because it is unknown, and the validator is set to not fetch unknown profiles
-Profile reference 'http://phr.kanta.fi/StructureDefinition/fiphr-sd-selfcareplan-r4' has not been checked because it is unknown, and the validator is set to not fetch unknown profiles
 Profile reference 'http://phr.kanta.fi/StructureDefinition/fiphr-sd-stepstaken' has not been checked because it is unknown, and the validator is set to not fetch unknown profiles
 
 # Roche's profile definitions are not part of this IG, but are referenced by some of the examples
@@ -38,8 +35,8 @@ Profile reference 'http://roche.com/fhir/rdc/StructureDefinition/medication-admi
 Profile reference 'http://example.org/StructureDefinition/other-bloodglucose-structuredefinition' has not been checked because it is unknown, and the validator is set to not fetch unknown profiles
 
 # OID based code systems cannot be validated.
-Code System URI 'urn:oid:1.2.246.537.5.40003.2003' is unknown so the code cannot be validated
-Code System URI 'urn:oid:1.2.246.537.5.40005.2003' is unknown so the code cannot be validated
+Code System URI 'urn:oid:1.2.246.537.5.40003' is unknown so the code cannot be validated
+Code System URI 'urn:oid:1.2.246.537.5.40005' is unknown so the code cannot be validated
 Code System URI 'urn:oid:1.2.246.537.5.40100.2006' is unknown so the code cannot be validated
 Code System URI 'urn:oid:1.2.246.537.5.40103.2006' is unknown so the code cannot be validated
 Code System URI 'urn:oid:1.2.246.537.5.40105.2006' is unknown so the code cannot be validated
@@ -48,44 +45,41 @@ Code System URI 'urn:oid:1.2.246.537.5.40118.2006' is unknown so the code cannot
 Code System URI 'urn:oid:1.2.246.537.5.40122.2006' is unknown so the code cannot be validated
 Code System URI 'urn:oid:1.2.246.537.5.40123.2006' is unknown so the code cannot be validated
 Code System URI 'urn:oid:1.2.246.537.5.40124.2006' is unknown so the code cannot be validated
-Code System URI 'urn:oid:1.2.246.537.5.40150.2009' is unknown so the code cannot be validated
 Code System URI 'urn:oid:1.2.246.537.5.40172' is unknown so the code cannot be validated
 Code System URI 'urn:oid:1.2.246.537.5.40202.201901' is unknown so the code cannot be validated
 Code System URI 'urn:oid:1.2.246.537.5.40303.201501' is unknown so the code cannot be validated
-Code System URI 'urn:oid:1.2.246.537.6.1.1999' is unknown so the code cannot be validated
-Code System URI 'urn:oid:1.2.246.537.6.110.2007' is unknown so the code cannot be validated
-Code System URI 'urn:oid:1.2.246.537.6.111.2007' is unknown so the code cannot be validated
-Code System URI 'urn:oid:1.2.246.537.6.121.201801' is unknown so the code cannot be validated
-Code System URI 'urn:oid:1.2.246.537.6.124.2008' is unknown so the code cannot be validated
-Code System URI 'urn:oid:1.2.246.537.6.125.2008' is unknown so the code cannot be validated
+Code System URI 'urn:oid:1.2.246.537.6.1' is unknown so the code cannot be validated
+Code System URI 'urn:oid:1.2.246.537.6.110' is unknown so the code cannot be validated
+Code System URI 'urn:oid:1.2.246.537.6.111' is unknown so the code cannot be validated
+Code System URI 'urn:oid:1.2.246.537.6.121' is unknown so the code cannot be validated
+Code System URI 'urn:oid:1.2.246.537.6.124' is unknown so the code cannot be validated
+Code System URI 'urn:oid:1.2.246.537.6.125' is unknown so the code cannot be validated
 Code System URI 'urn:oid:1.2.246.537.6.138.202001' is unknown so the code cannot be validated
+Code System URI 'urn:oid:1.2.246.537.6.140' is unknown so the code cannot be validated
 Code System URI 'urn:oid:1.2.246.537.6.140.2008' is unknown so the code cannot be validated
 Code System URI 'urn:oid:1.2.246.537.6.1403.202001' is unknown so the code cannot be validated
-Code System URI 'urn:oid:1.2.246.537.6.148.2008' is unknown so the code cannot be validated
-Code System URI 'urn:oid:1.2.246.537.6.2.2007' is unknown so the code cannot be validated
+Code System URI 'urn:oid:1.2.246.537.6.148' is unknown so the code cannot be validated
 Code System URI 'urn:oid:1.2.246.537.6.2' is unknown so the code cannot be validated
-Code System URI 'urn:oid:1.2.246.537.6.21.2003' is unknown so the code cannot be validated
+Code System URI 'urn:oid:1.2.246.537.6.21' is unknown so the code cannot be validated
 Code System URI 'urn:oid:1.2.246.537.6.270.202001' is unknown so the code cannot be validated
 Code System URI 'urn:oid:1.2.246.537.6.301' is unknown so the code cannot be validated
+Code System URI 'urn:oid:1.2.246.537.6.32' is unknown so the code cannot be validated
 Code System URI 'urn:oid:1.2.246.537.6.32.2007' is unknown so the code cannot be validated
-Code System URI 'urn:oid:1.2.246.537.6.49.201501' is unknown so the code cannot be validated
-Code System URI 'urn:oid:1.2.246.537.6.50.201801' is unknown so the code cannot be validated
+Code System URI 'urn:oid:1.2.246.537.6.49' is unknown so the code cannot be validated
+Code System URI 'urn:oid:1.2.246.537.6.50' is unknown so the code cannot be validated
 Code System URI 'urn:oid:1.2.246.537.6.601' is unknown so the code cannot be validated
 Code System URI 'urn:oid:1.2.246.537.6.604.2014' is unknown so the code cannot be validated
 Code System URI 'urn:oid:1.2.246.537.6.605.2014' is unknown so the code cannot be validated
-Code System URI 'urn:oid:1.2.246.537.6.609.201501' is unknown so the code cannot be validated
-Code System URI 'urn:oid:1.2.246.537.6.74.2001' is unknown so the code cannot be validated
-Code System URI 'urn:oid:1.2.246.537.6.884.2015' is unknown so the code cannot be validated
+Code System URI 'urn:oid:1.2.246.537.6.609' is unknown so the code cannot be validated
+Code System URI 'urn:oid:1.2.246.537.6.74' is unknown so the code cannot be validated
+Code System URI 'urn:oid:1.2.246.537.6.884' is unknown so the code cannot be validated
 Code System URI 'urn:oid:2.16.840.1.113883.18.220' is unknown so the code cannot be validated
 Code System URI 'urn:oid:2.16.840.1.113883.4.642.3.20' is unknown so the code cannot be validated
 
 # This is CGI's internal code system, not part of this IG, but present in some examples from CGI
 Code System URI 'https://fhir.cgi.fi/code/person-id-type' is unknown so the code cannot be validated
 
-# These are Kanta code systems, not part of this IG, but present in some examples from CGI
-Code System URI 'http://phr.kanta.fi/CodeSystem/fiphr-cs-careplancategory' is unknown so the code cannot be validated
+# These are Kanta code systems, not part of this IG, but present in some examples adopted from implementation guides for Kanta
 Code System URI 'http://phr.kanta.fi/CodeSystem/fiphr-cs-insulincode' is unknown so the code cannot be validated
 Code System URI 'http://phr.kanta.fi/CodeSystem/fiphr-cs-observationcategory' is unknown so the code cannot be validated
 Code System URI 'http://phr.kanta.fi/fiphr-cs-fitnesscategory' is unknown so the code cannot be validated
-Unknown Code System 'http://hl7.org/fhir/observation-category'
-URL value 'http://hl7.org/fhir/observation-category' does not resolve

--- a/input/pagecontent/StructureDefinition-fi-base-reason-for-care-intro.md
+++ b/input/pagecontent/StructureDefinition-fi-base-reason-for-care-intro.md
@@ -59,8 +59,8 @@ Other codes, like symptom and accident type SHOULD NOT be repetitions of `code`.
 
 More than one code may be used in `code` (in `code`'s repetitions of `coding`). `code` itself cannot
 be repeated. Currently ICD-10, ICPC2 are supported by THL, in near future ICD-11, SNOMED and ORPHA
-will become supported too). Additional codes may be expressed by repeating coding. Other codes like
-sympton SHOULD not be communicated via `code`, repetitions should represent the same concept (see
+will become supported too. Additional codes may be expressed by repeating coding. Other codes like
+a symptom SHOULD NOT be communicated via `code`, repetitions should represent the same concept (see
 [CodeableConcept datatype specification](https://www.hl7.org/fhir/datatypes.html#CodeableConcept)).
 
 Here's a valid example of repeating `code.coding` (`code` is not repeating, but `coding` has
@@ -70,12 +70,14 @@ repetitions expressing the same information in two code systems):
   "code" : {
     "coding" : [
       {
-        "system" : "urn:oid:1.2.246.537.6.1.1999",
+        "system" : "urn:oid:1.2.246.537.6.1",
+        "version" : "1999",
         "code" : "H36.03",
         "display" : "Proliferatiivinen diabeettinen retinopatia"
       },
       {
-        "system" : "urn:oid:1.2.246.537.6.31.2007",
+        "system" : "urn:oid:1.2.246.537.6.31",
+        "version" : "2007",
         "code" : "F83",
         "display" : "Retinopatia, verkkokalvon rappeuma"
       }
@@ -86,12 +88,14 @@ repetitions expressing the same information in two code systems):
 
 ##### Symptom code
 
+In THL specification, this data is `codeId 26`: *Diagnoosin tai käyntisyyn oirekoodi*.
+
 Symptom code SHOULD be communicated via `evidence`.
 
-When using Finnish ICD-10, code MUST NOT contain special characters (`+` after the code and `*` before
-code indicates symptom). Pre-built pairs (like E85.9+I68.0) code . SHALL be broken down to
-constituent parts and the code part indicating symptom (in case of in case of E85.9+I68.0, `Koodi2`
-field) used here.
+When using the Finnish ICD-10 version, the code MUST NOT contain special characters (`+` after the
+code and `*` before code indicating the symptom). Pre-built pairs (like E85.9+I68.0) SHALL be
+broken down to constituent parts and the code part indicating symptom (in case of E85.9+I68.0,
+`Koodi2` field).
 
 For example:
 
@@ -102,7 +106,8 @@ For example:
         {
           "coding" : [
             {
-              "system" : "urn:oid:1.2.246.537.6.1.1999",
+              "system" : "urn:oid:1.2.246.537.6.1",
+              "version" : "1999",
               "code" : "E11.3",
               "display" : "Aikuistyypin diabetes diabeteksen silmäkomplikaatiot"
             }
@@ -113,112 +118,118 @@ For example:
   ]
 ```
 
-In THL specification, this data is codeId 26: Diagnoosin tai käyntisyyn oirekoodi.
+##### Name of diagnosis
 
-##### When name differs from code.display
+In THL specification, this data is `codeId 21`: *Diagnoosin tai käyntisyyn nimi*.
 
-Medical doctor may make some adjustments to the name of the diagnosis. `code.display` MUST be the
-original name from the codesystem and `code.text` MAY contain adjusted name for the diagnosis.
+A practitioner may make some adjustments to the name of the diagnosis. `code.coding.display` SHALL
+still be the original name from the codesystem and `code.text` MAY contain an adjusted name for the
+diagnosis.
 
-In THL specification, this data is codeId 21: Diagnoosin tai käyntisyyn nimi.
+##### Primary diagnosis (*käyntisyy*)
 
-##### Primary/main diagnosis (or käyntisyy)
+In THL specification, this data is `codeId 2`: *Diagnoosin tai käyntisyyn ensisijaisuus*.
 
-Extension `primaryCondition` is used to express whether this is the primary/main condition for encounter.
+Extension `primaryCondition` is used to express whether this diagnosis is the primary condition for
+why the encounter takes place.
 
-Extension is a code from terminology "AR/YDIN - Diagnoosin /toimenpiteen ensisijaisuus" (1.2.246.537.5.40005.2003).
+The extension SHALL have a code from "*AR/YDIN - Diagnoosin /toimenpiteen ensisijaisuus*" (oid
+`1.2.246.537.5.40005`).
 
-In THL specification, this data is codeId 2: Diagnoosin tai käyntisyyn ensisijaisuus.
+##### Permanence (*pysyvyys*)
 
-##### Permanence (finnish "pysyvyys")
+In THL specification, this data is `codeId 8`: *Diagnoosin pysyvyys*.
 
-Extension `permanence` is used to express the condition is permanent or not.
+Extension `permanence` is used to express whether the condition is permanent or not.
 
-Extension is a code from terminology "AR/YDIN - Pysyvyys" (1.2.246.537.5.40003.2003).
+The extension SHALL have a code from "*AR/YDIN - Pysyvyys*" (oid `1.2.246.537.5.40003`).
 
-This information has some relation to `clinicalStatus`, but "AR/YDIN - Pysyvyys" can't be mapped to
-clinicalStatus codes (doing so would redefine clinicalStatus).
-
-In THL specification, this data is codeId 8: Diagnoosin pysyvyys.
+This information has some relation to `clinicalStatus`, but "*AR/YDIN - Pysyvyys*" cannot be mapped
+to clinicalStatus codes (doing so would redefine clinicalStatus).
 
 ##### Onset
 
-Standard `onset` SHOULD be used.
+In THL specification, this data is `codeId 12`: *Diagnoosin tai käyntisyyn toteamispäivä*.
 
-In THL specification, this data is codeId 12: Diagnoosin tai käyntisyyn toteamispäivä.
+Standard `onset` SHOULD be used.
 
 ##### Abatement
 
-Standard `abatement` MAY be used.
+In THL specification, this data is `codeId 16`: *Diagnoosin päättymispäivä*.
 
-In THL specification, this data is codeId 16: Diagnoosin päättymispäivä.
+Standard `abatement` MAY be used.
 
 ##### Asserter
 
 Standard `asserter` MAY be used.
 
-When `asserter` references a Practitioner, it can provide information for codeId 11: Toteajan nimi
-in THL specification. When `asserter` references a PractitionerRole, it can provide information for
-both codeId 11: Toteajan nimi and codeId 19: Toteajan palveluyksikkö.
+When `asserter` references a Practitioner, it can provide information for `codeId 11`:
+*Toteajan nimi* in THL specification. When `asserter` references a PractitionerRole, it can provide
+information for both `codeId 11`: *Toteajan nimi* and `codeId 19`: *Toteajan palveluyksikkö*.
 
 ##### Type of physical exercise during which injury occurred
 
-Extension `physicalExcercise`.
+In THL specification, this data is `codeId 24`: *Tapaturman liikuntalaji*.
 
-TODO add example.
-
-In THL specification, this data is codeId: 24 Tapaturman liikuntalaji.
+Extension `physicalExcercise` is used.
 
 ##### Endocrinological disorder
 
-Extension `endocrinologicalDisorder`.
+In THL specification, this data is `codeId 27`: *Endokrinologisen häiriön koodi*.
 
-TODO add example.
-
-In THL specification, this data is codeId: 27 Endokrinologisen häiriön koodi.
+Extension `endocrinologicalDisorder` is used.
 
 ##### Medication that caused this condition
 
-Extension `conditionCausedByMedication`  
+In THL specification, this data is `codeId 28`: *Aiheuttajan ATC-koodi*.
 
-In THL specification, this data is codeId: 28 Aiheuttajan ATC-koodi
+Extension `conditionCausedByMedication` is used.
 
 ##### External cause for diagnosis
 
-Extension `conditionExternalCause`
+In THL specification, this data is `codeId 3`: *Diagnoosin ulkoinen syy*.
 
-In THL specification, this data is codeId: 3 Diagnoosin ulkoinen syy
+Extension `conditionExternalCause` is used.
 
 ##### Categorization of the type of accident
 
-Extension `conditionCategorizationOfAccident`
+In THL specification, this data is `codeId 4`: *Diagnoosin tapaturmatyyppi*.
 
-In THL specification, this data is codeId: 4 Diagnoosin tapaturmatyyppi
+Extension `conditionCategorizationOfAccident` is used.
 
 ##### Cause of an adverse effect
 
-Extension `causeOfAdverseEffect`
+In THL specification, this data is `codeId 5`: *Haittavaikutuksen aiheuttaja*.
 
-In THL specification, this data is codeId: 5 Haittavaikutuksen aiheuttaja
+Extension `causeOfAdverseEffect` is used.
+
 
 ##### Further development needs
 
-Finnish diagnosis has some data that is not yet modeled in this profile. There is more modeling and
-mapping work to be done. Following list contains most relevant parts that need work:
-
-* Use of `problem-list-item` for long term diagnosis ("Pitkäaikaisdiagnoosi" or "Pysyvä diagnoosi" in finnish)? The conceptual mapping is not staightforward.
-* THL Tietosisältö 10 Tiedon lähde
-    * extension?
-* THL Tietosisältö 15 Diagnoosin päättymisen toteajan nimi
-* THL Tietosisältö 17 Diagnoosin päättymisen syy
-* THL Tietosisältö 18 Diagnoosin päättymisen syyn tarkenne
-* THL Tietosisältö 20 Diagnoosin päättymisen toteajan palveluyksikkö
-* THL Tietosisältö 22 Episodin nimi
-* THL Tietosisältö 7 Diagnoosin tai käyntisyyn varmuusaste
-    * map to [verificationStatus codes](https://hl7.org/fhir/R4/valueset-condition-ver-status.html)?
-* THL Tietosisältö 9 Diagnoosin tai käyntisyyn episoditunnus
+{:.stu-note}
+<div class="stu-note">
+  <p>Finnish diagnosis has some data that is not yet modeled in this profile. There is more
+    modeling and mapping work to be done. Following list contains most relevant parts that need
+    work:</p>
+  <ul>
+    <li>Use of `problem-list-item` for long term diagnosis (<i lang="fi">Pitkäaikaisdiagnoosi</i>
+    or <i lang="fi">Pysyvä diagnoosi</i>)? The conceptual mapping is not staightforward.</li>
+    <li><i lang="fi">THL Tietosisältö 10 Tiedon lähde</i>. Should this be an extension?</li>
+    <li><i lang="fi">THL Tietosisältö 15 Diagnoosin päättymisen toteajan nimi</i>.</li>
+    <li><i lang="fi">THL Tietosisältö 17 Diagnoosin päättymisen syy</i>.</li>
+    <li><i lang="fi">THL Tietosisältö 18 Diagnoosin päättymisen syyn tarkenne</i>.</li>
+    <li><i lang="fi">THL Tietosisältö 20 Diagnoosin päättymisen toteajan palveluyksikkö</i>.</li>
+    <li><i lang="fi">THL Tietosisältö 22 Episodin nimi</i>.</li>
+    <li><i lang="fi">THL Tietosisältö 7 Diagnoosin tai käyntisyyn varmuusaste</i>. This could
+    perhaps be mapped to <a
+    href="https://hl7.org/fhir/R4/valueset-condition-ver-status.html">verificationStatus
+    codes</a>.</li>
+    <li><i lang="fi">THL Tietosisältö 9 Diagnoosin tai käyntisyyn episoditunnus</i>.</li>
+  </ul>
+  <p>Feedback on all of the above is most welcome for further development of this profile.
+</div>
 
 #### Links
 
-* [Suomalainen tautien kirjaamisen ohjekirja](https://thl.fi/documents/10531/124365/Opas%202012%2017.pdf)
-national guide for the use if ICD-10.
+* [*Suomalainen tautien kirjaamisen ohjekirja*](https://thl.fi/documents/10531/124365/Opas%202012%2017.pdf),
+the national guide for the use of ICD-10.


### PR DESCRIPTION
An oid should not have the version string appended to it. There is a specific version field that is used for that.

Also, harmonize the way codeable concepts are written throughout profiles and eexamples. Use the shorthand version.

Improve the description for the FiBaseReasonForCare profile.